### PR TITLE
fix: align loopback doctor diagnostics and stale-state recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [1.0.1] - 2026-03-26
+
+### Changed
+
+- `mullgate doctor` now treats loopback direct bind-IP entrypoints as the canonical local path and downgrades missing local hostname shortcuts to advisory guidance instead of a hard failure
+- unsupported config-version errors now explain that old local config/runtime state must be replaced with a fresh `mullgate setup` plus `mullgate start`
+- README and operator docs now describe loopback direct-IP access as the default local path and document stale-state recovery explicitly
+
+### Fixed
+
+- loopback diagnostics no longer misclassify an otherwise usable local install as broken just because optional `/etc/hosts` shortcuts are incomplete
+
 ## [1.0.0] - 2026-03-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ mullgate status
 mullgate doctor
 ```
 
+In loopback mode, the direct bind-IP entrypoints reported by `mullgate status` and `mullgate exposure` are the canonical local access path. Run `mullgate hosts` only when you want local hostname shortcuts such as `sweden-gothenburg`.
+
+If an installed `mullgate` command reports an unsupported config version, treat that as stale local state. Back up or remove the config/runtime paths it prints, then rerun `mullgate setup` and `mullgate start` instead of trying to reuse the old runtime in place.
+
 ## platform support
 
 `mullgate` is currently a Linux-first runtime with truthful cross-platform install, config, and diagnostics surfaces.
@@ -230,7 +234,7 @@ macOS and Windows can install the CLI and report config/runtime state truthfully
 | `mullgate doctor` | none | run deterministic diagnostics for config, runtime, bind, DNS, and last-start failures |
 | `mullgate autostart` | `enable`, `disable`, `status` | manage a Linux `systemd --user` unit that starts the proxy runtime at login |
 | `mullgate path` | none | print active config/state/cache/runtime paths plus platform support posture |
-| `mullgate hosts` | none | print hostname to bind-IP mappings and the copy/paste hosts block |
+| `mullgate hosts` | none | print optional hostname to bind-IP mappings and the copy/paste hosts block for local hostname testing |
 | `mullgate export` | `--guided`, `--dry-run`, `--stdout` | generate authenticated proxy URL inventories with ordered country or region batches plus selective relay filters |
 | `mullgate relays` | `list`, `probe`, `verify` | inspect matching relays, rank candidates, and verify configured route exits through the published proxy protocols |
 | `mullgate recommend` | `--apply`, selector flags | probe matching relays, preview exact routes, and optionally pin recommended relay hostnames into saved config |
@@ -264,7 +268,7 @@ use one of the exposed routes from another client or shell:
 
 ```bash
 curl \
-  --proxy socks5h://sweden-gothenburg:1080 \
+  --proxy socks5h://127.0.0.1:1080 \
   --proxy-user "$MULLGATE_PROXY_USERNAME:$MULLGATE_PROXY_PASSWORD" \
   https://am.i.mullvad.net/json
 ```

--- a/docs/mullgate-docs/content/docs/guides/troubleshooting.mdx
+++ b/docs/mullgate-docs/content/docs/guides/troubleshooting.mdx
@@ -30,8 +30,10 @@ What to do:
 
 1. run `mullgate exposure`
 2. confirm the route-to-bind-IP mapping
-3. verify local hosts or DNS resolution
+3. if you are intentionally using hostname entrypoints, verify local hosts or DNS resolution
 4. run `mullgate doctor`
+
+In loopback mode without a base domain, direct bind-IP entrypoints are the canonical local path. Missing host-file mappings only matter when you want hostname shortcuts on that same machine.
 
 ### Remote clients cannot prove hostname-based routing
 
@@ -61,6 +63,20 @@ mullgate validate --refresh
 # or
 mullgate start
 ```
+
+### Installed command says the config version is unsupported
+
+Likely cause:
+
+- the local machine still has a stale pre-v2 config/runtime bundle
+
+What to do:
+
+1. back up or remove the config file and runtime directory named in the error
+2. rerun `mullgate setup`
+3. rerun `mullgate start`
+
+Do not expect the current CLI to operate on the old runtime bundle in place.
 
 ### macOS or Windows behaves differently from Linux
 

--- a/docs/mullgate-docs/content/docs/guides/usage.mdx
+++ b/docs/mullgate-docs/content/docs/guides/usage.mdx
@@ -95,6 +95,7 @@ What to expect:
 - route 1 gets `127.0.0.1`
 - route 2 gets `127.0.0.2`
 - the configured hostnames default to the route aliases in loopback mode
+- direct bind-IP entrypoints work immediately and are the canonical local access path
 - hostname access on the local machine works only after you install the emitted hosts block
 
 ![Private-network exposure demo](/images/demos/exposure-private-network.gif)
@@ -139,6 +140,19 @@ In that posture:
 - there are no DNS records to publish
 - direct bind-IP entrypoints are the intended access path
 - `mullgate hosts` is still useful for local-only hostname testing, but it is no longer required for remote clients
+
+## Unsupported local config versions
+
+The current CLI only operates on the current v2 config/runtime shape.
+
+If an installed `mullgate` command reports an unsupported config version:
+
+- treat the reported config/runtime paths as stale local state
+- back up or remove the config file and runtime directory named in the error
+- rerun `mullgate setup`
+- rerun `mullgate start`
+
+Do not expect the current CLI to keep operating on an older runtime bundle in place.
 
 ## Exporting proxy lists for clients
 
@@ -268,6 +282,8 @@ That mapping can come from:
 - published DNS records when you use `--base-domain`
 - some other trusted name-resolution system that preserves the same hostname-to-bind-IP mapping
 
+In loopback mode without a base domain, those hostname mappings are optional. Direct bind-IP entrypoints remain the canonical local path even when you skip the hosts block.
+
 ### Why the mapping matters for multi-route proof
 
 Mullgate's routing layer dispatches by **destination bind IP**, not by a late application-level hint. That means:
@@ -275,7 +291,7 @@ Mullgate's routing layer dispatches by **destination bind IP**, not by a late ap
 - every remote route needs its own bind IP
 - hostname proof only works when name resolution lands on the correct IP first
 - if two hostnames resolve to the same bind IP, they collapse to the same route
-- if a hostname resolves somewhere else, `mullgate doctor` reports hostname drift and points you back to `mullgate hosts`
+- in DNS-backed or non-loopback hostname setups, `mullgate doctor` reports hostname drift and points you back to `mullgate hosts`
 
 ### Example `curl` forms
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -93,6 +93,7 @@ What to expect:
 - route 1 gets `127.0.0.1`
 - route 2 gets `127.0.0.2`
 - the configured hostnames default to the route aliases in loopback mode
+- direct bind-IP entrypoints work immediately and are the canonical local access path
 - hostname access on the local machine works only after you install the emitted hosts block
 
 ### Example: private-network hostnames with a base domain
@@ -135,6 +136,19 @@ In that posture:
 - there are no DNS records to publish
 - direct bind-IP entrypoints are the intended access path
 - `mullgate hosts` is still useful for local-only hostname testing, but it is no longer required for remote clients
+
+## Unsupported local config versions
+
+The current CLI only operates on the current v2 config/runtime shape.
+
+If an installed `mullgate` command reports an unsupported config version:
+
+- treat the reported config/runtime paths as stale local state
+- back up or remove the config file and runtime directory named in the error
+- rerun `mullgate setup`
+- rerun `mullgate start`
+
+Do not expect the current CLI to keep operating on an older runtime bundle in place.
 
 ## Relay discovery, recommendation, and exit verification
 
@@ -213,6 +227,8 @@ That can come from:
 - published DNS records when you use `--base-domain`
 - some other trusted name-resolution system that preserves the same hostname → bind IP mapping
 
+In loopback mode without a base domain, those hostname mappings are optional. Direct bind-IP entrypoints remain the canonical local path even when you skip the hosts block.
+
 ### Why the mapping matters for multi-route proof
 
 Mullgate's routing layer dispatches by **destination bind IP**, not by a late application-level hint. That means:
@@ -220,7 +236,7 @@ Mullgate's routing layer dispatches by **destination bind IP**, not by a late ap
 - every remote route needs its own bind IP
 - hostname proof only works when name resolution lands on the correct IP first
 - if two hostnames resolve to the same bind IP, they collapse to the same route
-- if a hostname resolves somewhere else, `mullgate doctor` reports hostname drift and points you back to `mullgate hosts`
+- in DNS-backed or non-loopback hostname setups, `mullgate doctor` reports hostname drift and points you back to `mullgate hosts`
 
 ### Example curl forms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mullgate",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Microck",
   "keywords": [
     "mullvad",

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -644,6 +644,7 @@ async function buildHostnameCheck(
   exposure: ExposureContract,
   resolveHostname: (hostname: string) => Promise<readonly string[]>,
 ): Promise<DoctorCheck> {
+  const directBindIpCanonical = usesDirectBindIpLoopbackAccess(config);
   const details: string[] = [];
   const failures: string[] = [];
 
@@ -674,6 +675,21 @@ async function buildHostnameCheck(
   }
 
   if (failures.length > 0) {
+    if (directBindIpCanonical) {
+      return {
+        name: 'hostname-resolution',
+        outcome: 'degraded',
+        summary:
+          'Loopback hostname shortcuts are incomplete, but direct bind-IP entrypoints remain the canonical local access path.',
+        details: [
+          'Loopback mode without a base domain keeps direct bind-IP entrypoints canonical. Install host-file mappings only if you want local hostname shortcuts.',
+          ...details,
+          ...failures,
+        ],
+        remediation: buildHostnameRemediation(config, exposure),
+      };
+    }
+
     return {
       name: 'hostname-resolution',
       outcome: 'fail',
@@ -686,9 +702,15 @@ async function buildHostnameCheck(
   return {
     name: 'hostname-resolution',
     outcome: 'pass',
-    summary:
-      'Configured hostnames resolve to the bind IPs promised by the saved exposure contract.',
-    details,
+    summary: directBindIpCanonical
+      ? 'Loopback direct bind-IP entrypoints are canonical, and the optional hostname shortcuts currently resolve correctly.'
+      : 'Configured hostnames resolve to the bind IPs promised by the saved exposure contract.',
+    details: directBindIpCanonical
+      ? [
+          'Loopback mode without a base domain keeps direct bind-IP entrypoints canonical. Hostname shortcuts are optional for local testing.',
+          ...details,
+        ]
+      : details,
   };
 }
 
@@ -1116,6 +1138,10 @@ function buildStartFailureRemediation(lastStart: RuntimeStartDiagnostic): string
 }
 
 function buildHostnameRemediation(config: MullgateConfig, exposure: ExposureContract): string {
+  if (usesDirectBindIpLoopbackAccess(config)) {
+    return 'Keep using the direct bind-IP entrypoints for normal loopback access. If you want hostname-based local testing, use `mullgate hosts` and install the emitted hosts block on this machine.';
+  }
+
   if (config.setup.exposure.baseDomain) {
     return 'Publish or update the saved DNS A records so every route hostname resolves to its saved bind IP, then rerun `mullgate doctor`.';
   }
@@ -1125,6 +1151,10 @@ function buildHostnameRemediation(config: MullgateConfig, exposure: ExposureCont
   }
 
   return 'Use the direct bind-IP entrypoints from the saved exposure contract when hostnames are not available.';
+}
+
+function usesDirectBindIpLoopbackAccess(config: MullgateConfig): boolean {
+  return config.setup.exposure.mode === 'loopback' && config.setup.exposure.baseDomain === null;
 }
 
 function describeRouteContext(lastStart: RuntimeStartDiagnostic): string {

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -26,9 +26,7 @@ class UnsupportedConfigVersionError extends Error {
   readonly version: number;
 
   constructor(version: number) {
-    super(
-      `Config version ${version} is no longer supported. Mullgate now requires a version ${CONFIG_VERSION} config with one shared WireGuard device and exact per-route exits. Re-run \`mullgate setup\` to create a fresh config.`,
-    );
+    super(`Config version ${version} is no longer supported.`);
     this.name = 'UnsupportedConfigVersionError';
     this.version = version;
   }
@@ -136,7 +134,11 @@ export class ConfigStore {
           source: 'file',
           paths: this.paths,
           artifactPath: this.paths.configFile,
-          message: error.message,
+          message: [
+            `Config version ${error.version} is no longer supported. Mullgate now requires a version ${CONFIG_VERSION} config with one shared WireGuard device and exact per-route exits.`,
+            'This is stale local state, not a config the current CLI will operate.',
+            `Back up or remove ${this.paths.configFile} and the runtime artifacts under ${this.paths.runtimeDir}, then rerun \`mullgate setup\` and \`mullgate start\`.`,
+          ].join(' '),
         };
       }
 

--- a/test/cli/doctor-command.test.ts
+++ b/test/cli/doctor-command.test.ts
@@ -556,7 +556,8 @@ describe('mullgate doctor command', () => {
          detail: route[2] at-vie-wg-001 bind-ip=127.0.0.2
 
       7. hostname-resolution: pass
-         summary: Configured hostnames resolve to the bind IPs promised by the saved exposure contract.
+         summary: Loopback direct bind-IP entrypoints are canonical, and the optional hostname shortcuts currently resolve correctly.
+         detail: Loopback mode without a base domain keeps direct bind-IP entrypoints canonical. Hostname shortcuts are optional for local testing.
          detail: route se-got-wg-101: se-got-wg-101 -> 127.0.0.1
          detail: route at-vie-wg-001: at-vie-wg-001 -> 127.0.0.2
 
@@ -759,7 +760,8 @@ describe('mullgate doctor command', () => {
          detail: route[2] at-vie-wg-001 bind-ip=127.0.0.2
 
       7. hostname-resolution: pass
-         summary: Configured hostnames resolve to the bind IPs promised by the saved exposure contract.
+         summary: Loopback direct bind-IP entrypoints are canonical, and the optional hostname shortcuts currently resolve correctly.
+         detail: Loopback mode without a base domain keeps direct bind-IP entrypoints canonical. Hostname shortcuts are optional for local testing.
          detail: route se-got-wg-101: se-got-wg-101 -> 127.0.0.1
          detail: route at-vie-wg-001: at-vie-wg-001 -> 127.0.0.2
 
@@ -874,12 +876,12 @@ describe('mullgate doctor command', () => {
 
     await action();
 
-    expect(process.exitCode).toBe(1);
-    expect(stdout.value.current).toBe('');
-    expect(`\n${normalizeOutput(stderr.value.current, env)}`).toMatchInlineSnapshot(`
+    expect(process.exitCode).toBe(0);
+    expect(stderr.value.current).toBe('');
+    expect(`\n${normalizeOutput(stdout.value.current, env)}`).toMatchInlineSnapshot(`
       "
       Mullgate doctor
-      overall: fail
+      overall: degraded
       checked at: 2026-03-21T08:00:00.000Z
       mode: offline-default
       config: /tmp/mullgate-home/config/mullgate/config.json
@@ -960,12 +962,13 @@ describe('mullgate doctor command', () => {
          detail: route[1] se-got-wg-101 bind-ip=127.0.0.1
          detail: route[2] at-vie-wg-001 bind-ip=127.0.0.2
 
-      7. hostname-resolution: fail
-         summary: One or more route hostnames no longer resolve to their saved bind IPs.
+      7. hostname-resolution: degraded
+         summary: Loopback hostname shortcuts are incomplete, but direct bind-IP entrypoints remain the canonical local access path.
+         detail: Loopback mode without a base domain keeps direct bind-IP entrypoints canonical. Install host-file mappings only if you want local hostname shortcuts.
          detail: route se-got-wg-101: se-got-wg-101 -> 127.0.0.1
          detail: route at-vie-wg-001: at-vie-wg-001 -> 127.0.0.9
          detail: Route at-vie-wg-001 expects at-vie-wg-001 to resolve to 127.0.0.2, but it currently resolves to 127.0.0.9.
-         remediation: Use \`mullgate hosts\` and install the emitted hosts block on this machine so each route hostname resolves to its saved bind IP, then rerun \`mullgate doctor\`.
+         remediation: Keep using the direct bind-IP entrypoints for normal loopback access. If you want hostname-based local testing, use \`mullgate hosts\` and install the emitted hosts block on this machine.
 
       8. runtime: degraded
          summary: No live compose containers are running right now.
@@ -980,6 +983,353 @@ describe('mullgate doctor command', () => {
          detail: routing-layer=not present in live compose status
          detail: route se-got-wg-101 publishes se-got-wg-101 -> 127.0.0.1 via route-proxy
          detail: route at-vie-wg-001 publishes at-vie-wg-001 -> 127.0.0.2 via route-proxy
+         remediation: Run \`mullgate start\` after fixing any validation, bind, or last-start issues reported above.
+
+      9. last-start: degraded
+         summary: No persisted last-start diagnostic exists yet.
+         detail: Doctor can still inspect saved config and live runtime state, but there is no persisted start failure/success context yet.
+         remediation: Run \`mullgate start\` once to capture a persisted launch report that future doctor runs can inspect."
+    `);
+  });
+
+  it('keeps loopback hostname shortcuts advisory when direct bind-IP entrypoints are still canonical', async () => {
+    const env = createTempEnvironment();
+    const { store, paths } = await seedSavedConfig(env, {
+      configure: (config) => ({
+        ...config,
+        runtime: {
+          ...config.runtime,
+          status: {
+            phase: 'running',
+            lastCheckedAt: '2026-03-21T07:58:00.000Z',
+            message: 'Runtime is already up.',
+          },
+        },
+      }),
+    });
+    const stdout = createBufferSink();
+    const stderr = createBufferSink();
+
+    const action = createDoctorCommandAction({
+      store,
+      stdout,
+      stderr,
+      checkedAt: '2026-03-21T08:00:00.000Z',
+      resolveHostname: async (hostname) => {
+        if (hostname === 'se-got-wg-101') {
+          return ['127.0.0.1'];
+        }
+        if (hostname === 'at-vie-wg-001') {
+          throw new Error('getaddrinfo ENOTFOUND at-vie-wg-001');
+        }
+        throw new Error(`Unexpected hostname ${hostname}`);
+      },
+      inspectRuntime: async () =>
+        createComposeStatusSuccess(paths.runtimeComposeFile, [
+          {
+            name: 'mullgate-entry-tunnel-1',
+            service: 'entry-tunnel',
+            project: 'mullgate',
+            state: 'running',
+            health: 'healthy',
+            status: 'Up 40 seconds',
+            exitCode: 0,
+            publishers: [],
+          },
+          {
+            name: 'mullgate-route-proxy-1',
+            service: 'route-proxy',
+            project: 'mullgate',
+            state: 'running',
+            health: 'healthy',
+            status: 'Up 40 seconds',
+            exitCode: 0,
+            publishers: [],
+          },
+          {
+            name: 'mullgate-routing-layer-1',
+            service: 'routing-layer',
+            project: 'mullgate',
+            state: 'running',
+            health: 'healthy',
+            status: 'Up 40 seconds',
+            exitCode: 0,
+            publishers: [],
+          },
+        ]),
+    });
+
+    await action();
+
+    expect(process.exitCode).toBe(0);
+    expect(stderr.value.current).toBe('');
+    expect(`\n${normalizeOutput(stdout.value.current, env)}`).toMatchInlineSnapshot(`
+      "
+      Mullgate doctor
+      overall: degraded
+      checked at: 2026-03-21T08:00:00.000Z
+      mode: offline-default
+      config: /tmp/mullgate-home/config/mullgate/config.json
+      runtime dir: /tmp/mullgate-home/state/mullgate/runtime
+      relay cache: /tmp/mullgate-home/cache/mullgate/relays.json
+      entry wireproxy config: /tmp/mullgate-home/state/mullgate/runtime/entry-wireproxy.conf
+      route proxy config: /tmp/mullgate-home/state/mullgate/runtime/route-proxy.cfg
+      runtime validation report: /tmp/mullgate-home/state/mullgate/runtime/runtime-validation.json
+      runtime manifest: /tmp/mullgate-home/state/mullgate/runtime/runtime-manifest.json (present)
+      last start report: /tmp/mullgate-home/state/mullgate/runtime/last-start.json (missing)
+
+      checks
+      1. config: pass
+         summary: Loaded the canonical Mullgate config successfully.
+         detail: config=/tmp/mullgate-home/config/mullgate/config.json
+         detail: routes=2
+         detail: saved-runtime-phase=running
+         detail: exposure-mode=loopback
+
+      2. platform-support: pass
+         summary: Current platform matches the fully supported Linux runtime contract.
+         detail: platform=linux
+         detail: platform-source=env:MULLGATE_PLATFORM
+         detail: support-level=full
+         detail: mode-label=Linux-first runtime support
+         detail: summary=Linux is the fully supported Mullgate runtime environment. The shipped Docker host-networking model, per-route bind IP listeners, and runtime-manifest diagnostics are designed around Linux network semantics.
+         detail: runtime-story=Use Linux for the full setup, runtime, status, and doctor workflow with the current Docker-first topology.
+         detail: config-paths=supported
+         detail: config-workflow=supported
+         detail: runtime-artifacts=supported
+         detail: runtime-execution=supported
+         detail: diagnostics=supported
+         detail: host-networking=Native host networking available
+         detail: host-networking-summary=Docker host networking behaves as expected on Linux, so the routing layer and shared route-proxy listeners can bind directly to the saved route IPs.
+         detail: guidance=Linux is the reference runtime target for the current Mullgate topology and verification flow.
+         detail: guidance=Path inspection, runtime-manifest rendering, status, and doctor should all agree on this Linux support posture without extra platform-specific wording.
+
+      3. validation-artifacts: pass
+         summary: Shared entry-wireproxy and route-proxy artifacts are present, and the persisted runtime validation report passed.
+         detail: saved-runtime-phase=running
+         detail: saved-runtime-message=Runtime is already up.
+         detail: entry-wireproxy-config=/tmp/mullgate-home/state/mullgate/runtime/entry-wireproxy.conf (present)
+         detail: route-proxy-config=/tmp/mullgate-home/state/mullgate/runtime/route-proxy.cfg (present)
+         detail: validation-report=/tmp/mullgate-home/state/mullgate/runtime/runtime-validation.json
+         detail: validation-status=success
+         detail: validation-source=validation-suite
+         detail: check[entry-wireproxy]=ok via internal-syntax/internal-syntax
+         detail: check[route-proxy]=ok via internal-syntax/internal-syntax
+
+      4. relay-cache: pass
+         summary: Saved Mullvad relay metadata is readable and fresh enough for offline diagnostics.
+         detail: relay-cache=/tmp/mullgate-home/cache/mullgate/relays.json
+         detail: source=app-wireguard-v1
+         detail: endpoint=https://api.mullvad.net/public/relays/wireguard/v1/
+         detail: fetched-at=2026-03-21T07:55:00.000Z
+         detail: relay-count=2
+         detail: age=0h
+
+      5. exposure-contract: pass
+         summary: Saved exposure contract is internally coherent.
+         detail: mode=loopback
+         detail: mode-label=Loopback / local-only
+         detail: recommendation=local-default
+         detail: posture-summary=Recommended default for same-machine use. Remote clients are intentionally out of scope in this posture.
+         detail: remote-story=Switch to private-network mode for Tailscale, LAN, or other trusted-overlay remote access.
+         detail: base-domain=n/a
+         detail: allow-lan=no
+         detail: dns-records=0
+         detail: routes=2
+         detail: bind-remediation=Keep loopback mode on local-only bind IPs. If you need remote access, rerun \`mullgate exposure --mode private-network ...\` with one trusted-network bind IP per route.
+         detail: hostname-remediation=For local host-file testing, use \`mullgate hosts\` and apply the emitted block on this machine so each route hostname resolves to its saved loopback bind IP.
+         detail: restart-remediation=After changing exposure settings, rerun \`mullgate validate\` or \`mullgate start\` so the runtime artifacts match the saved local-only posture.
+         detail: info: Loopback mode is local-only. Keep using \`mullgate hosts\` for host-file testing on this machine.
+
+      6. bind-posture: pass
+         summary: Saved bind IPs match the configured exposure posture.
+         detail: setup.bind.host=127.0.0.1
+         detail: route[1] se-got-wg-101 bind-ip=127.0.0.1
+         detail: route[2] at-vie-wg-001 bind-ip=127.0.0.2
+
+      7. hostname-resolution: degraded
+         summary: Loopback hostname shortcuts are incomplete, but direct bind-IP entrypoints remain the canonical local access path.
+         detail: Loopback mode without a base domain keeps direct bind-IP entrypoints canonical. Install host-file mappings only if you want local hostname shortcuts.
+         detail: route se-got-wg-101: se-got-wg-101 -> 127.0.0.1
+         detail: Route at-vie-wg-001 could not resolve at-vie-wg-001: getaddrinfo ENOTFOUND at-vie-wg-001.
+         remediation: Keep using the direct bind-IP entrypoints for normal loopback access. If you want hostname-based local testing, use \`mullgate hosts\` and install the emitted hosts block on this machine.
+
+      8. runtime: pass
+         summary: Live Docker Compose status matches the expected shared entry-tunnel, route-proxy, and routing-layer services.
+         detail: compose-command=docker compose --file /tmp/mullgate-home/state/mullgate/runtime/docker-compose.yml ps --all --format json
+         detail: containers=3
+         detail: running=3
+         detail: starting=0
+         detail: stopped=0
+         detail: unhealthy=0
+         detail: entry-tunnel=running (status=Up 40 seconds, health=healthy, exit=0)
+         detail: route-proxy=running (status=Up 40 seconds, health=healthy, exit=0)
+         detail: routing-layer=running (status=Up 40 seconds, health=healthy, exit=0)
+         detail: route se-got-wg-101 publishes se-got-wg-101 -> 127.0.0.1 via route-proxy
+         detail: route at-vie-wg-001 publishes at-vie-wg-001 -> 127.0.0.2 via route-proxy
+
+      9. last-start: degraded
+         summary: No persisted last-start diagnostic exists yet.
+         detail: Doctor can still inspect saved config and live runtime state, but there is no persisted start failure/success context yet.
+         remediation: Run \`mullgate start\` once to capture a persisted launch report that future doctor runs can inspect."
+    `);
+  });
+
+  it('still fails hostname resolution for DNS-backed hostnames that drift away from their bind IPs', async () => {
+    const env = createTempEnvironment();
+    const { store, paths } = await seedSavedConfig(env, {
+      configure: (config) => ({
+        ...config,
+        setup: {
+          ...config.setup,
+          bind: {
+            ...config.setup.bind,
+            host: '192.168.10.10',
+          },
+          exposure: {
+            ...config.setup.exposure,
+            mode: 'private-network',
+            allowLan: true,
+            baseDomain: 'proxy.example.com',
+          },
+        },
+        routing: {
+          locations: config.routing.locations.map((location, index) => ({
+            ...location,
+            bindIp: index === 0 ? '192.168.10.10' : '192.168.10.11',
+            hostname: `${location.alias}.proxy.example.com`,
+          })),
+        },
+      }),
+    });
+    const stdout = createBufferSink();
+    const stderr = createBufferSink();
+
+    const action = createDoctorCommandAction({
+      store,
+      stdout,
+      stderr,
+      checkedAt: '2026-03-21T08:00:00.000Z',
+      resolveHostname: async (hostname) => {
+        if (hostname === 'sweden-gothenburg.proxy.example.com') {
+          return ['192.168.10.10'];
+        }
+        if (hostname === 'austria-vienna.proxy.example.com') {
+          return ['192.168.10.99'];
+        }
+        throw new Error(`Unexpected hostname ${hostname}`);
+      },
+      inspectRuntime: async () => createComposeStatusSuccess(paths.runtimeComposeFile, []),
+    });
+
+    await action();
+
+    expect(process.exitCode).toBe(1);
+    expect(stdout.value.current).toBe('');
+    expect(`\n${normalizeOutput(stderr.value.current, env)}`).toMatchInlineSnapshot(`
+      "
+      Mullgate doctor
+      overall: fail
+      checked at: 2026-03-21T08:00:00.000Z
+      mode: offline-default
+      config: /tmp/mullgate-home/config/mullgate/config.json
+      runtime dir: /tmp/mullgate-home/state/mullgate/runtime
+      relay cache: /tmp/mullgate-home/cache/mullgate/relays.json
+      entry wireproxy config: /tmp/mullgate-home/state/mullgate/runtime/entry-wireproxy.conf
+      route proxy config: /tmp/mullgate-home/state/mullgate/runtime/route-proxy.cfg
+      runtime validation report: /tmp/mullgate-home/state/mullgate/runtime/runtime-validation.json
+      runtime manifest: /tmp/mullgate-home/state/mullgate/runtime/runtime-manifest.json (present)
+      last start report: /tmp/mullgate-home/state/mullgate/runtime/last-start.json (missing)
+
+      checks
+      1. config: pass
+         summary: Loaded the canonical Mullgate config successfully.
+         detail: config=/tmp/mullgate-home/config/mullgate/config.json
+         detail: routes=2
+         detail: saved-runtime-phase=validated
+         detail: exposure-mode=private-network
+
+      2. platform-support: pass
+         summary: Current platform matches the fully supported Linux runtime contract.
+         detail: platform=linux
+         detail: platform-source=env:MULLGATE_PLATFORM
+         detail: support-level=full
+         detail: mode-label=Linux-first runtime support
+         detail: summary=Linux is the fully supported Mullgate runtime environment. The shipped Docker host-networking model, per-route bind IP listeners, and runtime-manifest diagnostics are designed around Linux network semantics.
+         detail: runtime-story=Use Linux for the full setup, runtime, status, and doctor workflow with the current Docker-first topology.
+         detail: config-paths=supported
+         detail: config-workflow=supported
+         detail: runtime-artifacts=supported
+         detail: runtime-execution=supported
+         detail: diagnostics=supported
+         detail: host-networking=Native host networking available
+         detail: host-networking-summary=Docker host networking behaves as expected on Linux, so the routing layer and shared route-proxy listeners can bind directly to the saved route IPs.
+         detail: guidance=Linux is the reference runtime target for the current Mullgate topology and verification flow.
+         detail: guidance=Path inspection, runtime-manifest rendering, status, and doctor should all agree on this Linux support posture without extra platform-specific wording.
+
+      3. validation-artifacts: pass
+         summary: Shared entry-wireproxy and route-proxy artifacts are present, and the persisted runtime validation report passed.
+         detail: saved-runtime-phase=validated
+         detail: saved-runtime-message=Fixture config already validated.
+         detail: entry-wireproxy-config=/tmp/mullgate-home/state/mullgate/runtime/entry-wireproxy.conf (present)
+         detail: route-proxy-config=/tmp/mullgate-home/state/mullgate/runtime/route-proxy.cfg (present)
+         detail: validation-report=/tmp/mullgate-home/state/mullgate/runtime/runtime-validation.json
+         detail: validation-status=success
+         detail: validation-source=validation-suite
+         detail: check[entry-wireproxy]=ok via internal-syntax/internal-syntax
+         detail: check[route-proxy]=ok via internal-syntax/internal-syntax
+
+      4. relay-cache: pass
+         summary: Saved Mullvad relay metadata is readable and fresh enough for offline diagnostics.
+         detail: relay-cache=/tmp/mullgate-home/cache/mullgate/relays.json
+         detail: source=app-wireguard-v1
+         detail: endpoint=https://api.mullvad.net/public/relays/wireguard/v1/
+         detail: fetched-at=2026-03-21T07:55:00.000Z
+         detail: relay-count=2
+         detail: age=0h
+
+      5. exposure-contract: pass
+         summary: Saved exposure contract is internally coherent.
+         detail: mode=private-network
+         detail: mode-label=Private network / Tailscale-first
+         detail: recommendation=recommended-remote
+         detail: posture-summary=Recommended remote posture. Use this for Tailscale, LAN, or other trusted private overlays before considering public exposure.
+         detail: remote-story=Keep bind IPs private, ensure route hostnames resolve inside the trusted network, and use \`mullgate hosts\` when local host-file wiring is the easiest path.
+         detail: base-domain=proxy.example.com
+         detail: allow-lan=yes
+         detail: dns-records=2
+         detail: routes=2
+         detail: bind-remediation=Keep private-network mode on trusted-network bind IPs only. Use one distinct RFC1918 or overlay-network address per route so destination-IP routing stays truthful.
+         detail: hostname-remediation=Make each route hostname resolve to its saved private-network bind IP inside Tailscale/LAN DNS, or use \`mullgate hosts\` when host-file wiring is the intended local workaround.
+         detail: restart-remediation=After exposure or bind-IP changes, rerun \`mullgate validate\` or \`mullgate start\` so the runtime artifacts and operator guidance match the recommended private-network posture.
+         detail: info: Publish one DNS A record per route hostname and point it at the matching bind IP before expecting remote hostname access to work.
+
+      6. bind-posture: pass
+         summary: Saved bind IPs match the configured exposure posture.
+         detail: setup.bind.host=192.168.10.10
+         detail: route[1] se-got-wg-101 bind-ip=192.168.10.10
+         detail: route[2] at-vie-wg-001 bind-ip=192.168.10.11
+
+      7. hostname-resolution: fail
+         summary: One or more route hostnames no longer resolve to their saved bind IPs.
+         detail: route se-got-wg-101: sweden-gothenburg.proxy.example.com -> 192.168.10.10
+         detail: route at-vie-wg-001: austria-vienna.proxy.example.com -> 192.168.10.99
+         detail: Route at-vie-wg-001 expects austria-vienna.proxy.example.com to resolve to 192.168.10.11, but it currently resolves to 192.168.10.99.
+         remediation: Publish or update the saved DNS A records so every route hostname resolves to its saved bind IP, then rerun \`mullgate doctor\`.
+
+      8. runtime: degraded
+         summary: No live compose containers are running right now.
+         detail: compose-command=docker compose --file /tmp/mullgate-home/state/mullgate/runtime/docker-compose.yml ps --all --format json
+         detail: containers=0
+         detail: running=0
+         detail: starting=0
+         detail: stopped=0
+         detail: unhealthy=0
+         detail: entry-tunnel=not present in live compose status
+         detail: route-proxy=not present in live compose status
+         detail: routing-layer=not present in live compose status
+         detail: route se-got-wg-101 publishes sweden-gothenburg.proxy.example.com -> 192.168.10.10 via route-proxy
+         detail: route at-vie-wg-001 publishes austria-vienna.proxy.example.com -> 192.168.10.11 via route-proxy
          remediation: Run \`mullgate start\` after fixing any validation, bind, or last-start issues reported above.
 
       9. last-start: degraded
@@ -1158,7 +1508,8 @@ describe('mullgate doctor command', () => {
          detail: route[2] at-vie-wg-001 bind-ip=127.0.0.2
 
       7. hostname-resolution: pass
-         summary: Configured hostnames resolve to the bind IPs promised by the saved exposure contract.
+         summary: Loopback direct bind-IP entrypoints are canonical, and the optional hostname shortcuts currently resolve correctly.
+         detail: Loopback mode without a base domain keeps direct bind-IP entrypoints canonical. Hostname shortcuts are optional for local testing.
          detail: route se-got-wg-101: se-got-wg-101 -> 127.0.0.1
          detail: route at-vie-wg-001: at-vie-wg-001 -> 127.0.0.2
 

--- a/test/config-store.test.ts
+++ b/test/config-store.test.ts
@@ -194,6 +194,12 @@ function createLegacyFixtureConfig(env: NodeJS.ProcessEnv): Record<string, unkno
   };
 }
 
+function createUnsupportedVersionFixtureConfig(env: NodeJS.ProcessEnv): Record<string, unknown> {
+  const config = JSON.parse(JSON.stringify(createFixtureConfig(env))) as Record<string, unknown>;
+  config.version = 1;
+  return config;
+}
+
 afterEach(async () => {
   cleanupWindowsFixturePaths();
   await Promise.all(
@@ -484,6 +490,38 @@ describe('mullgate config store', () => {
         ],
       },
     });
+  });
+
+  it('fails with an operator recovery message for unsupported config versions', async () => {
+    const env = createTempEnvironment();
+    const paths = resolveMullgatePaths(env);
+    const store = new ConfigStore(paths);
+    const staleConfig = createUnsupportedVersionFixtureConfig(env);
+
+    await mkdir(path.dirname(paths.configFile), { recursive: true, mode: 0o700 });
+    await writeFile(paths.configFile, `${JSON.stringify(staleConfig, null, 2)}\n`, 'utf8');
+
+    const loaded = await store.load();
+
+    expect(loaded).toMatchObject({
+      ok: false,
+      phase: 'parse-config',
+      source: 'file',
+      artifactPath: paths.configFile,
+      paths,
+    });
+
+    if (loaded.ok) {
+      return;
+    }
+
+    expect(loaded.message).toContain('Config version 1 is no longer supported.');
+    expect(loaded.message).toContain(
+      'This is stale local state, not a config the current CLI will operate.',
+    );
+    expect(loaded.message).toContain(paths.configFile);
+    expect(loaded.message).toContain(paths.runtimeDir);
+    expect(loaded.message).toContain('rerun `mullgate setup` and `mullgate start`');
   });
 
   it('persists routed configs atomically and mirrors the first route back into legacy fields', async () => {


### PR DESCRIPTION
## Summary

- make `mullgate doctor` treat loopback direct bind-IP entrypoints as the canonical local path
- downgrade missing loopback hostname shortcuts to advisory guidance instead of a hard failure
- improve unsupported config-version recovery messaging so stale local state gets replaced cleanly
- update README, operator docs, and tests to match the shipped behavior
- cut the `1.0.1` release metadata in `package.json` and `CHANGELOG.md`

## Verification

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test -- --run`

If packaging, install flow, or release behavior changed:

- [x] `pnpm verify:install-smoke`
- [x] `pnpm verify:m003-install-path -- --check-only`

## Docs and release notes

- [x] README or docs updated if user-facing behavior changed
- [x] CHANGELOG updated if this should ship in release notes

## Risks

- GitHub npm automation may not publish because the repository currently shows no `NPM_TOKEN` / `NPM_PUBLISH_ENABLED` secrets, so the manual publish path may be required for npm.