### PR TITLE
[nightshift] CI/CD Fixes: workflow bugs and dependabot enhancement

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,34 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: monday
     open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - npm
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+    groups:
+      production-dependencies:
+        dependency-type: production
+      development-dependencies:
+        dependency-type: development
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: monday
     open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,7 @@ jobs:
   publish:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       id-token: write
@@ -41,6 +42,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.release_tag) || github.event.workflow_run.head_sha }}
 
+      - name: Install pnpm
+        if: ${{ steps.check-publish-flag.outputs.enabled == 'true' }}
+        uses: pnpm/action-setup@v5.0.0
+        with:
+          version: 10.18.3
+
       - name: Setup Node.js
         if: ${{ steps.check-publish-flag.outputs.enabled == 'true' }}
         uses: actions/setup-node@v6.3.0
@@ -48,12 +55,6 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
           cache: pnpm
-
-      - name: Install pnpm
-        if: ${{ steps.check-publish-flag.outputs.enabled == 'true' }}
-        uses: pnpm/action-setup@v5.0.0
-        with:
-          version: 10.18.3
 
       - name: Install dependencies
         if: ${{ steps.check-publish-flag.outputs.enabled == 'true' }}

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -116,7 +116,7 @@ jobs:
             binary_name: mullgate
             smoke_command: ''
             run_smoke: false
-          - os: macos-15-intel
+          - os: macos-13
             target: x86_64-apple-darwin
             bun_target: bun-darwin-x64
             archive_ext: tar.gz

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,20 +16,22 @@ permissions:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6.3.0
-        with:
-          node-version: 22
-
       - name: Install pnpm
         uses: pnpm/action-setup@v5.0.0
         with:
           version: 10.18.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version: 22
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** CI/CD Fixes
**Category:** PR
**Changes:**
- **npm-publish.yml**: Fixed step order (pnpm before node) to fix broken pnpm cache, added timeout-minutes: 15
- **security.yml**: Added cache: pnpm to node setup, fixed step order, added timeout-minutes: 10
- **release-package.yml**: Replaced invalid `macos-15-intel` runner with `macos-13` (standard Intel macOS runner)
- **dependabot.yml**: Enhanced with labels, dependency grouping, commit conventions, and schedule

Found real bugs: pnpm cache silently failing in npm-publish.yml due to step order, and invalid macOS runner causing build matrix failures.

Merge if useful, close if not.