### PR TITLE
feat(access): add inline selector proxy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- README, usage guides, docs-site pages, and command/config references now document the `inline-selector` access mode, the guaranteed `selector:@host:port` syntax, the public empty-password safety override, and the current `published-routes`-only export limitation
+
 ### Fixed
 
 ## [1.1.0] - 2026-04-01

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ flowchart TB
     end
 
     subgraph runtime[Linux-first live runtime]
-        listeners[route-specific SOCKS5, HTTP, and HTTPS listeners]
-        router[routing by shared-host ports or destination bind IP]
+        listeners[route-specific or shared-selector SOCKS5, HTTP, and HTTPS listeners]
+        router[routing by shared-host ports, destination bind IP, or selector username]
         backends[one rendered backend per configured route]
         docker[Docker runtime bundle]
     end
@@ -209,7 +209,7 @@ mullgate proxy doctor
 
 ![setup demo](images/demos/setup-guided.gif)
 
-In loopback mode, the direct bind-IP entrypoints reported by `mullgate proxy status` and `mullgate proxy access` are the canonical local access path. `mullgate proxy access` now combines the old exposure and hosts views into one access report.
+In loopback mode, the direct bind-IP entrypoints reported by `mullgate proxy status` and `mullgate proxy access` are the canonical local access path. `mullgate proxy access` now combines the old exposure and hosts views into one access report, and it is also where you switch between the default `published-routes` model and the opt-in `inline-selector` model.
 
 If an installed `mullgate` command reports an unsupported config version, treat that as stale local state. Back up or remove the config/runtime paths it prints, then rerun `mullgate setup` and `mullgate proxy start` instead of trying to reuse the old runtime in place.
 
@@ -230,8 +230,8 @@ macOS and Windows can install the CLI and report config/runtime state truthfully
 | command | key flags | purpose |
 | --- | --- | --- |
 | `mullgate setup` | `--non-interactive`, `--location`, `--exposure-mode` | create or update canonical config and derived runtime artifacts |
-| `mullgate proxy access` | `--mode`, `--base-domain`, `--route-bind-ip` | inspect or update hostnames, the shared private-network host or public bind IPs, DNS guidance, and direct-IP entrypoints |
-| `mullgate proxy export` | `--regions`, `--guided`, selector flags | list region groups or generate client-ready proxy inventories |
+| `mullgate proxy access` | `--mode`, `--access-mode`, `--base-domain`, `--route-bind-ip` | inspect or update exposure posture, access mode, shared-host planning, DNS guidance, selector examples, and direct-IP entrypoints |
+| `mullgate proxy export` | `--regions`, `--guided`, selector flags | list region groups or generate client-ready proxy inventories for `published-routes` mode |
 | `mullgate proxy relay list` | selector flags such as `--country`, `--owner`, `--provider` | inspect relay candidates that match a policy |
 | `mullgate proxy relay probe` | `--country`, `--count` | latency-probe likely relay candidates |
 | `mullgate proxy relay recommend` | `--country`, `--count`, `--apply` | preview or pin an exact relay choice |
@@ -270,6 +270,25 @@ mullgate setup --non-interactive
 mullgate proxy access
 ```
 
+switch that same trusted-network host to selector-driven access when you want one shared listener and route selection in the proxy username:
+
+```bash
+mullgate proxy access \
+  --mode private-network \
+  --access-mode inline-selector \
+  --route-bind-ip 100.124.44.113
+```
+
+with `inline-selector`, the guaranteed URL shape is `scheme://selector:@host:port`. for example:
+
+```text
+socks5://se:@100.124.44.113:1080
+socks5://se-got:@100.124.44.113:1080
+socks5://se-got-wg-101:@100.124.44.113:1080
+```
+
+the shorter `scheme://selector@host:port` form is best-effort only because some clients do not normalize a missing password consistently. if you expose `inline-selector` on a public host with an empty password, Mullgate blocks that by default until you opt in with `--unsafe-public-empty-password`.
+
 start the runtime and inspect its current posture:
 
 ```bash
@@ -295,6 +314,8 @@ mullgate proxy export --guided
 mullgate proxy export --country se --city got --count 1 --region europe --provider m247 --owner mullvad --run-mode ram --min-port-speed 9000 --count 2 --output proxies.txt
 mullgate proxy export --dry-run --protocol http --country us --server us-nyc-wg-001 --owner rented
 ```
+
+`mullgate proxy export` currently supports `published-routes` mode only. if you switch to `inline-selector`, use `mullgate proxy access` to inspect the shared listener and selector examples instead of expecting per-route export output.
 
 inspect candidate relays, preview the fastest exact match, then verify a configured exit:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,123 +1,161 @@
 ---
 name: use-mullgate
-description: Install, configure, run, verify, and troubleshoot Mullgate as an operator on a real machine. Use when the task is to actually use Mullgate rather than develop the Mullgate codebase, including first-run setup, non-interactive setup, exposure planning, hostname and bind-IP configuration, proxy export, relay discovery, exact-exit recommendation, route verification, runtime checks, or Linux autostart.
+description: Install, configure, run, verify, and troubleshoot Mullgate as an operator on a real machine. Use when the task is to actually use Mullgate rather than develop the Mullgate codebase, including first-run setup, non-interactive setup, Tailscale or private-network exposure, inline selector access, proxy export, relay discovery, exact-exit recommendation, route verification, and Linux autostart.
 ---
 
 # Use Mullgate
 
 ## Overview
 
-Operate Mullgate as a user-facing proxy tool. Use the existing Mullgate docs to choose the right setup path, exposure mode, verification sequence, and troubleshooting flow without drifting into repo-maintainer or release workflows.
+Operate Mullgate as a user-facing proxy gateway. Stay on the operator path: choose the right exposure and access mode, verify the saved/runtime state, and give the user concrete proxy URLs or commands that match the current CLI.
 
 ## Grounding
 
 Read these sources before acting:
 
-- `README.md` for the landing-page install and command surface
+- `README.md` for the install path and top-level command surface
 - `docs/usage.md` for the full operator workflow
-- `docs/mullgate-docs/content/docs/guides/setup-and-exposure.mdx` for bind-IP and hostname planning
+- `docs/mullgate-docs/content/docs/guides/setup-and-exposure.mdx` for exposure and access planning
 - `docs/mullgate-docs/content/docs/guides/troubleshooting.mdx` for failure diagnosis
 - `docs/mullgate-docs/content/docs/reference/commands.mdx` for command relationships
 
-Do not use `docs/maintainers/` for operator tasks. Those pages are for release, publishing, docs-site work, and demo maintenance.
-
-## Workflow Decision Tree
-
-Choose the path that matches the user’s goal:
-
-- Install or verify the CLI:
-  - Prefer the checked-in installer path from `README.md`
-  - Verify with `mullgate --help` and `mullgate config path`
-- First-time local proof:
-  - Prefer Linux
-  - Prefer `loopback` exposure with two routes
-  - Run `mullgate setup`, then `mullgate proxy access`
-- Automated or repeatable setup:
-  - Use `mullgate setup --non-interactive`
-  - Start from `.env.example`
-- LAN, VPN, or overlay exposure:
-  - Use `private-network`
-  - Require one distinct bind IP per route
-  - Use a base domain only when real route hostnames are needed
-- Public exposure:
-  - Use only when internet-reachable listeners are explicitly intended
-  - Treat it as a higher-risk posture and verify it carefully
-- Relay choice and exact-exit proof:
-  - Use `mullgate relays list`, `mullgate relays probe`, `mullgate proxy relay recommend`, and `mullgate relays verify`
-- Runtime diagnosis:
-  - Start with `mullgate proxy access`, `mullgate proxy access`, `mullgate proxy status`, and `mullgate proxy doctor`
+Do not use `docs/maintainers/` for operator tasks.
 
 ## Mental Model
 
-- Mullgate is not a full-device VPN client. It is a local proxy gateway with explicit per-route entrypoints.
-- Mullgate provisions one shared Mullvad WireGuard entry device and fans out to per-route Mullvad SOCKS5 exits, so route count does not imply one Mullvad slot per route.
-- Route selection stays truthful only when hostnames resolve to the route’s assigned bind IP.
-- In non-loopback multi-route setups, distinct routes require distinct bind IPs.
-- `status`, `doctor`, `hosts`, and `exposure` are part of the product surface, not optional extras.
+Treat Mullgate as two separate choices:
 
-## Operating Rules
+- `setup.exposure.mode`
+  - `loopback` - local-only proof on one machine
+  - `private-network` - one trusted-network host, usually a LAN or Tailscale IP
+  - `public` - internet-reachable listeners
+- `setup.access.mode`
+  - `published-routes` - default; routes are selected by hostname or per-route port inventory
+  - `inline-selector` - opt-in; one shared listener per protocol and the route selector goes in the proxy username
 
-- Prefer the installed `mullgate` command in examples and commands.
-- Treat Linux as the only fully supported live runtime environment.
-- On macOS and Windows, keep install, config, `path`, `status`, and `doctor` truthful, but do not claim the shipped Docker runtime is fully equivalent to Linux.
-- Use `mullgate setup` for guided setup unless the user explicitly wants automation.
-- Use `mullgate setup --non-interactive` only when all required inputs are available through flags or environment variables.
-- Do not describe Mullgate as consuming one Mullvad WireGuard device per route. The current runtime uses one shared entry device and many logical exits.
-- Keep hostname-based routing truthful: each non-loopback route needs its own bind IP, and each hostname must resolve to that route’s bind IP.
-- Prefer `mullgate proxy access` and `mullgate proxy access` over hand-written explanations when deciding whether a hostname or bind plan is correct.
-- Use `mullgate validate --refresh` or `mullgate proxy start` after exposure changes when derived runtime state may be stale.
-- Keep `mullgate recommend --apply` tied to exact relay hostnames, not broad selectors.
+Important rules:
 
-## Practical Command Sequences
+- `private-network` should use the host's trusted-network IP, not `0.0.0.0`. On Tailscale, that usually means the host `100.x` address.
+- In `private-network + published-routes`, all routes can share one host IP because route selection moves to per-route ports.
+- In `inline-selector`, one shared host works in every exposure mode because route selection moves to the username.
+- Proxy passwords are optional. If omitted, Mullgate saves an empty password.
+- `public + inline-selector + empty password` is blocked unless the operator explicitly enables `--unsafe-public-empty-password` or `setup.access.allowUnsafePublicEmptyPassword=true`.
+- `mullgate proxy export` currently supports `published-routes` only.
 
-Use these sequences as the default operator flow:
+## Intent Mapping
+
+Map the user's request to the Mullgate mode first:
+
+- "Set up Mullgate locally" or "prove it works on this machine"
+  - Use `loopback`
+  - Keep the default `published-routes`
+- "Expose Mullgate over Tailscale", "use it from another machine on my VPN", or "private network"
+  - Use `private-network`
+  - Prefer the host's Tailscale `100.x` IP when available
+- "Use one host and choose country/city/server in the proxy URL itself"
+  - Use `private-network` unless the user explicitly wants public exposure
+  - Switch to `inline-selector`
+- "Give me a proxy list/file I can import elsewhere"
+  - Keep or switch to `published-routes`
+  - Use `mullgate proxy export`
+- "Make it public on the internet"
+  - Use `public`
+  - Push back if they also want an empty password
+- "Start automatically after reboot"
+  - Use `mullgate proxy autostart enable`
+  - Verify with `mullgate proxy autostart status`
+
+## Default Workflows
 
 ### Install and verify
 
-1. Install Mullgate.
-2. Run `mullgate --help`.
-3. Run `mullgate config path`.
+1. Run `mullgate --help`.
+2. Run `mullgate config path`.
+3. Run `mullgate setup` or `mullgate setup --non-interactive`.
 
-### First working setup
-
-1. Run `mullgate setup` or `mullgate setup --non-interactive`.
-2. Run `mullgate proxy access` for local hostname mapping.
-3. Run `mullgate proxy access` to inspect mode, hostnames, and bind IPs.
-4. Run `mullgate proxy start`.
-5. Run `mullgate proxy status`.
-6. Run `mullgate proxy doctor`.
-
-### Client export and exit tuning
-
-1. Run `mullgate proxy export --regions`.
-2. Run `mullgate export --guided` or a deterministic `mullgate export ...` selector sequence.
-3. Run `mullgate relays list` to inspect candidates.
-4. Run `mullgate relays probe` to compare likely exits.
-5. Run `mullgate proxy relay recommend` to preview, then `--apply` if requested.
-6. Run `mullgate relays verify --route <route>` to prove the configured exit.
-
-### Troubleshooting
+### Inspect or change exposure/access
 
 1. Run `mullgate proxy access`.
-2. Run `mullgate proxy access`.
-3. Run `mullgate validate --refresh` if config changed.
+2. If needed, run `mullgate proxy access --mode ... --access-mode ... --route-bind-ip ...`.
+3. Run `mullgate proxy validate --refresh` or `mullgate proxy start`.
 4. Run `mullgate proxy status`.
 5. Run `mullgate proxy doctor`.
-6. Run a real probe through the intended proxy entrypoint.
+
+### Relay choice and exact-exit proof
+
+1. Run `mullgate proxy relay list`.
+2. Run `mullgate proxy relay probe`.
+3. Run `mullgate proxy relay recommend`.
+4. If the user wants a pinned exact exit, apply the recommendation.
+5. Run `mullgate proxy relay verify --route <route>`.
+
+### Autostart
+
+1. Run `mullgate proxy autostart enable`.
+2. Run `mullgate proxy autostart status`.
+3. If startup still fails after reboot, inspect `mullgate proxy status` and `mullgate proxy doctor`.
+
+## Tailscale Playbook
+
+When the user asks for requests like "open Canada through Tailscale" or "make Sweden available from another Tailscale machine", prefer this path:
+
+1. Use `private-network`.
+2. Prefer `inline-selector` if the user wants one stable host and selector-driven URLs.
+3. Use the host's Tailscale IP as the exposed host, for example `100.124.44.113`.
+4. Start the runtime and verify the access report.
+5. Hand back concrete client URLs.
+
+Example command sequence:
+
+```bash
+mullgate proxy access \
+  --mode private-network \
+  --access-mode inline-selector \
+  --route-bind-ip 100.124.44.113
+
+mullgate proxy start
+mullgate proxy access
+```
+
+Example client URLs:
+
+```text
+socks5://ca:@100.124.44.113:1080
+http://ca:@100.124.44.113:8080
+socks5://ca-tor:@100.124.44.113:1080
+socks5://ca-tor-wg-301:@100.124.44.113:1080
+```
+
+Use the guaranteed `scheme://selector:@host:port` form. The shorter `scheme://selector@host:port` form is best-effort only.
+
+If the user instead wants a generated proxy inventory file, do not use `inline-selector`. Keep `published-routes` and use:
+
+```bash
+mullgate proxy export --guided
+```
+
+## Operator Rules
+
+- Prefer the installed `mullgate` command in examples.
+- Prefer `mullgate proxy access` over editing JSON by hand.
+- Use `mullgate proxy access` to inspect selector examples, hostname guidance, and direct-IP entrypoints.
+- After changing exposure mode, access mode, base domain, or bind host, refresh runtime state with `mullgate proxy validate --refresh` or restart with `mullgate proxy start`.
+- Use `mullgate proxy export` only in `published-routes` mode.
+- Use `mullgate proxy access` rather than guessing which URL syntax a client should use.
+- Treat Linux as the only fully supported runtime environment.
 
 ## What To Watch For
 
-- Missing required non-interactive inputs
-- Shared bind IPs across multiple non-loopback routes
-- Hostnames resolving to the wrong bind IP
-- DNS that does not match `mullgate proxy access`
-- Runtime state that was not refreshed after config edits
-- HTTPS enabled without both cert and key material
-- Users expecting macOS or Windows Docker runtime behavior to match Linux
+- Using `0.0.0.0` as if it were a client-reachable host address
+- Expecting `private-network` to require one bind IP per route
+- Expecting `mullgate proxy export` to work in `inline-selector`
+- Public exposure with an empty password
+- Runtime state left `unvalidated` after access or exposure changes
+- Tailscale clients using the wrong host IP instead of the Mullgate host's `100.x` address
 
 ## Output Style
 
-- Prefer operator-facing answers over repo-maintainer explanations.
-- Give concrete commands in the order the user should run them.
-- When diagnosing a problem, name the likely failure layer first: install, config, exposure, hostname resolution, runtime state, or exit verification.
-- If the user asks whether a setup is valid, anchor the answer to Mullgate’s actual exposure and routing rules rather than generic proxy advice.
+- Prefer short, operator-facing answers with concrete commands.
+- If the user asks for a working proxy URL, give the exact URL shape they should use.
+- If the user asks for a list or file, switch to the export workflow instead of inventing selector URLs.
+- If a request is risky, say why and name the safer alternative.

--- a/docs/mullgate-docs/content/docs/architecture/overview.mdx
+++ b/docs/mullgate-docs/content/docs/architecture/overview.mdx
@@ -3,7 +3,7 @@ title: Architecture Overview
 description: High-level design goals, traffic flow, and trust boundaries for Mullgate.
 ---
 
-Mullgate is a gateway-oriented proxy system. It presents local route-specific proxy entrypoints while keeping the operator in control of how traffic is exposed, validated, and observed.
+Mullgate is a gateway-oriented proxy system. It presents route-specific or selector-driven proxy entrypoints while keeping the operator in control of how traffic is exposed, validated, and observed.
 
 ## Design goals
 
@@ -38,11 +38,11 @@ Destination / observed exit
 
 That flow matters because Mullgate is not trying to hide routing. It is trying to make routing legible.
 
-## Why bind IPs matter
+## Why exposure and access semantics matter
 
-A major architectural point in Mullgate is that route selection is tied to destination bind IPs. That is what allows hostname-selected behavior to stay consistent across multiple proxy protocols, including cases where protocol-level hostname hints are not reliable enough for routing decisions.
+A major architectural point in Mullgate is that route selection follows the configured access mode. In `published-routes`, route selection is tied to destination bind IPs or published ports. In `inline-selector`, the selector in the proxy username chooses the backend.
 
-In practice, that means the DNS or `/etc/hosts` mapping is part of the route contract.
+In practice, that means the DNS or `/etc/hosts` mapping is part of the route contract in `published-routes`, while selector syntax is part of the route contract in `inline-selector`.
 
 ## Operational surfaces
 

--- a/docs/mullgate-docs/content/docs/faq.mdx
+++ b/docs/mullgate-docs/content/docs/faq.mdx
@@ -13,11 +13,32 @@ Not in the usual full-device sense. Mullgate's documented goal is standalone pro
 
 ## How do I choose a route?
 
-Use the route's configured hostname or its direct entrypoint. In `private-network` mode, multiple routes can share one host IP because the ports differ. In `loopback` and `public` mode, hostname truth still depends on the hostname resolving to the route's bind IP.
+Use the saved access mode:
+
+- in `published-routes`, use the route's configured hostname or its direct host-and-port entrypoint
+- in `inline-selector`, use one shared listener and put the selector in the username, for example `socks5://ca:@100.124.44.113:1080`
+
+In `private-network + published-routes`, multiple routes can share one host IP because the ports differ.
 
 ## Why are bind IPs so important?
 
-They still define the published host story, but the runtime is now split by mode. `private-network` uses one shared trusted-network host IP and route-specific ports. `loopback` and `public` still rely on destination bind IPs.
+They still define the published host story, but the runtime is split by exposure and access mode. `private-network + published-routes` uses one shared trusted-network host IP and route-specific ports. `public + published-routes` still relies on distinct bind IPs. `inline-selector` uses one shared host because the username selector chooses the route.
+
+## Should I use `0.0.0.0` for Tailscale or other private-network access?
+
+No. `0.0.0.0` is a bind-any address, not the client target other machines should dial. In `private-network`, use the host's actual trusted-network address, such as its Tailscale `100.x` IP.
+
+## Can I put the country, city, or exact server into the proxy username?
+
+Yes, if you switch to `inline-selector`. The guaranteed form is `scheme://selector:@host:port`.
+
+Examples:
+
+- `socks5://ca:@100.124.44.113:1080`
+- `socks5://ca-tor:@100.124.44.113:1080`
+- `socks5://ca-tor-wg-301:@100.124.44.113:1080`
+
+If you want a generated file of route URLs instead, stay on `published-routes` and use `mullgate proxy export`.
 
 ## What is the easiest way to test Mullgate locally?
 
@@ -55,6 +76,10 @@ Check the output from:
 
 Most hostname issues come down to a missing hosts block, incorrect DNS, or a hostname resolving to the wrong bind IP.
 In `private-network`, "wrong" usually means the hostname does not resolve to the shared host IP that `mullgate proxy access` reported.
+
+## Why does public inline-selector reject my empty password?
+
+That combination exposes one shared public listener and is blocked by default. Either set a non-empty proxy password or opt in explicitly with `--unsafe-public-empty-password`.
 
 ## See also
 

--- a/docs/mullgate-docs/content/docs/getting-started/quickstart.mdx
+++ b/docs/mullgate-docs/content/docs/getting-started/quickstart.mdx
@@ -34,7 +34,7 @@ A normal Mullgate workflow looks like this:
 4. inspect or probe relay candidates when you want a better exact exit
 5. start the runtime with `mullgate proxy start`
 6. verify behavior with `mullgate proxy status` and `mullgate proxy doctor`
-7. access routes by hostname or direct bind IP
+7. access routes by hostname/direct host-and-port in `published-routes`, or by inline selector on one shared listener in `inline-selector`
 
 ## Recommended first run
 
@@ -57,6 +57,8 @@ mullgate proxy relay recommend --country Sweden --count 1
 ```
 
 That gives you a guided `proxies.txt` flow with real country and region pick-lists, plus a relay-inspection path when you want to preview a faster exact exit instead of guessing.
+
+If the goal is Tailscale or another trusted private network, the next step after setup is usually `mullgate proxy access --mode private-network`. If the goal is one stable host with country/city selection in the proxy URL, switch to `--access-mode inline-selector`.
 
 See the full examples in [Usage](/docs/guides/usage) and [Setup and Exposure](/docs/guides/setup-and-exposure).
 

--- a/docs/mullgate-docs/content/docs/guides/setup-and-exposure.mdx
+++ b/docs/mullgate-docs/content/docs/guides/setup-and-exposure.mdx
@@ -3,17 +3,25 @@ title: Setup and Exposure
 description: How Mullgate setup, bind IPs, hostnames, and exposure modes fit together.
 ---
 
-This guide extracts the setup and exposure model from the main usage document and presents it as an operator-oriented walkthrough.
+This guide extracts the setup, exposure, and access model from the main usage document and presents it as an operator-oriented walkthrough.
 
 ## Exposure modes
 
-Mullgate describes exposure in terms of how clients reach per-route listeners.
+Mullgate separates:
 
-The main modes referenced in the CLI are:
+- **exposure mode** - where the listeners are reachable
+- **access mode** - how a client selects the route behind that listener
+
+The exposure modes referenced in the CLI are:
 
 - `loopback`
 - `private-network`
 - `public`
+
+The access modes are:
+
+- `published-routes` - default
+- `inline-selector` - opt-in
 
 ## Loopback mode
 
@@ -23,7 +31,8 @@ Typical characteristics:
 
 - route 1 binds to `127.0.0.1`
 - additional routes bind to other loopback addresses such as `127.0.0.2`
-- route aliases act as local hostnames after you install the generated hosts block
+- in `published-routes`, route aliases act as local hostnames after you install the generated hosts block
+- in `inline-selector`, one shared loopback listener is enough because the username selector chooses the route
 
 This is the best starting point for local validation.
 
@@ -34,7 +43,8 @@ Use private-network mode when clients are on a LAN, VPN, or overlay network and 
 Typical characteristics:
 
 - all routes share one trusted-network host IP
-- each route gets its own published port on that shared host
+- in `published-routes`, each route gets its own published port on that shared host
+- in `inline-selector`, clients use one shared listener and put the selector in the proxy username
 - when Tailscale is available, the setup flow should default to the host's `100.x` address
 - a base domain can be used to produce route-aware hostnames such as `sweden-gothenburg.proxy.example.com`
 
@@ -51,17 +61,24 @@ Mullgate supports both:
 - hostname-based entrypoints
 - direct-IP entrypoints
 
-The same route can be reached through either form, but hostname-based routing only remains truthful when the hostname resolves to the route's assigned bind IP.
+In `published-routes`, the same route can be reached through either form, but hostname-based routing only remains truthful when the hostname resolves to the intended host IP and port combination.
 
-## Why bind IPs still matter
+In `inline-selector`, the shared listener stays fixed and the username selector chooses the route. The guaranteed URL form is:
 
-The exposure model is now split:
+```text
+scheme://selector:@host:port
+```
+
+## Why exposure and access both matter
+
+The current rules are:
 
 - `loopback` still derives route-local bind IPs such as `127.0.0.1` and `127.0.0.2`
-- `private-network` reuses one shared host IP and moves route selection to per-route ports
-- `public` still depends on distinct bind IPs per route
+- `private-network + published-routes` reuses one shared host IP and moves route selection to per-route ports
+- `public + published-routes` still depends on distinct bind IPs per route
+- `inline-selector` uses one shared host in any exposure mode because route selection moves to the proxy username
 
-DNS correctness is still part of route correctness. In private-network mode, multiple hostnames can legitimately point at the same host IP because the ports differ.
+DNS correctness is still part of route correctness. In `private-network + published-routes`, multiple hostnames can legitimately point at the same host IP because the ports differ.
 
 ## Inspect current exposure
 
@@ -72,10 +89,12 @@ mullgate proxy access
 Use this report to verify:
 
 - mode
+- access mode
 - base domain
 - shared host or route-to-bind-IP mapping
 - generated hostname inventory
-- DNS records to publish
+- DNS records to publish in `published-routes`
+- selector examples in `inline-selector`
 - whether runtime validation or restart is needed
 
 ## Update exposure safely
@@ -88,6 +107,15 @@ Example:
 mullgate proxy access \
   --mode private-network \
   --base-domain proxy.example.com \
+  --route-bind-ip 100.124.44.113
+```
+
+Or switch that same trusted-network host to selector-driven access:
+
+```bash
+mullgate proxy access \
+  --mode private-network \
+  --access-mode inline-selector \
   --route-bind-ip 100.124.44.113
 ```
 
@@ -108,7 +136,8 @@ mullgate proxy start
 Before you finalize exposure settings, make sure you can answer these questions:
 
 - How many routes are you exposing?
-- Is private-network using one trusted host IP, or is public mode using distinct bind IPs?
+- Is the user selecting routes through published host/port inventory or through inline selectors?
+- Is private-network using one trusted host IP, or is public `published-routes` mode using distinct bind IPs?
 - Which hostnames should clients use?
 - Do those hostnames resolve to the intended host IPs?
 - Is the environment loopback, private network, or public?
@@ -117,7 +146,7 @@ Before you finalize exposure settings, make sure you can answer these questions:
 
 Before claiming hostname-selected routing works remotely, verify all of the following:
 
-- private-network routes share the intended trusted host IP, or public routes keep distinct bind IPs
+- private-network routes share the intended trusted host IP, or public `published-routes` routes keep distinct bind IPs
 - every hostname resolves to the intended host IP
 - `mullgate proxy access` matches your DNS plan
 - `mullgate proxy doctor` shows no hostname drift

--- a/docs/mullgate-docs/content/docs/guides/troubleshooting.mdx
+++ b/docs/mullgate-docs/content/docs/guides/troubleshooting.mdx
@@ -12,7 +12,6 @@ The primary diagnostic surfaces are:
 - `mullgate proxy status`
 - `mullgate proxy doctor`
 - `mullgate proxy access`
-- `mullgate proxy access`
 - `mullgate proxy validate --refresh`
 
 ## Common problems
@@ -39,16 +38,30 @@ In loopback mode without a base domain, direct bind-IP entrypoints are the canon
 
 Check for:
 
-- shared bind IPs in a multi-route non-loopback setup
+- the wrong host IP being shared with clients, especially `0.0.0.0` instead of the real Tailscale or LAN IP
 - missing or incorrect DNS records
 - exposure changes that have not been refreshed into runtime state
 
 What to do:
 
-1. assign one explicit bind IP per route
+1. use the real private-network host IP, such as the Mullgate host's Tailscale `100.x` address
 2. regenerate or review exposure output
 3. publish matching DNS A records
 4. run `mullgate proxy validate --refresh` or `mullgate proxy start`
+
+### Inline selector URLs do not select the expected route
+
+Check for:
+
+- the client URL using `scheme://selector@host:port` and dropping the empty password
+- a selector that does not match any saved route or relay filter
+- public exposure with an empty password but no explicit unsafe override
+
+What to do:
+
+1. switch to the guaranteed `scheme://selector:@host:port` form
+2. inspect selector examples with `mullgate proxy access`
+3. if the listener is public and the password is empty, add `--unsafe-public-empty-password` or set a real password
 
 ### Saved configuration changed but runtime does not match
 
@@ -103,7 +116,7 @@ Use `mullgate proxy status` and `mullgate proxy doctor` to identify which layer 
 A reliable sequence is:
 
 1. inspect configuration with `mullgate proxy access`
-2. inspect hostname guidance with `mullgate proxy access`
+2. inspect hostname guidance or selector examples with `mullgate proxy access`
 3. refresh derived runtime state with `mullgate proxy validate --refresh`
 4. check runtime truth with `mullgate proxy status`
 5. investigate routing or hostname drift with `mullgate proxy doctor`
@@ -114,7 +127,9 @@ A reliable sequence is:
 If the issue remains unclear, answer these questions explicitly:
 
 - what exposure mode is configured?
-- does every route have a distinct bind IP?
+- what access mode is configured?
+- if this is `public + published-routes`, does every route have a distinct bind IP?
+- if this is `private-network`, are clients using the Mullgate host's real private-network IP?
 - what does the hostname resolve to from the failing client?
 - was the runtime refreshed after the last config edit?
 - are you testing on Linux, macOS, or Windows?

--- a/docs/mullgate-docs/content/docs/guides/usage.mdx
+++ b/docs/mullgate-docs/content/docs/guides/usage.mdx
@@ -45,7 +45,6 @@ Use Linux for the full setup/runtime/probe workflow. On macOS and Windows, treat
 | --- | --- | --- |
 | Mullvad account number | `--account-number <digits>` | `MULLGATE_ACCOUNT_NUMBER` |
 | Proxy username | `--username <name>` | `MULLGATE_PROXY_USERNAME` |
-| Proxy password | `--password <secret>` | `MULLGATE_PROXY_PASSWORD` |
 | One or more routed locations | `--location <alias>` (repeatable) | `MULLGATE_LOCATION` or `MULLGATE_LOCATIONS` |
 
 ### Common optional inputs
@@ -57,6 +56,7 @@ Use Linux for the full setup/runtime/probe workflow. On macOS and Windows, treat
 | Shared private-network host IP or public per-route bind IPs | `--route-bind-ip <ip>` (repeatable) | `MULLGATE_ROUTE_BIND_IPS` |
 | Exposure mode | `--exposure-mode <mode>` | `MULLGATE_EXPOSURE_MODE` |
 | Base domain | `--base-domain <domain>` | `MULLGATE_EXPOSURE_BASE_DOMAIN` |
+| Proxy password | `--password <secret>` | `MULLGATE_PROXY_PASSWORD` |
 | SOCKS5 port | `--socks-port <port>` | `MULLGATE_SOCKS_PORT` |
 | HTTP port | `--http-port <port>` | `MULLGATE_HTTP_PORT` |
 | HTTPS port | `--https-port <port>` | `MULLGATE_HTTPS_PORT` |
@@ -70,8 +70,10 @@ Notes:
 - `MULLGATE_LOCATION` is shorthand for route 1.
 - `MULLGATE_LOCATIONS` is the ordered, comma-separated form for multi-route setup.
 - `MULLGATE_ROUTE_BIND_IPS` is also ordered and comma-separated.
+- If you omit `MULLGATE_PROXY_PASSWORD`, setup saves an empty password.
 - `private-network` uses one shared trusted-network host IP. If Tailscale is available during setup and you do not override it, Mullgate should default to the host's `100.x` address.
-- `public` still requires one explicit bind IP per routed location, and multi-route public exposure still requires **distinct** bind IPs.
+- `public` plus the default `published-routes` access mode still requires one explicit bind IP per routed location, and multi-route public exposure still requires **distinct** bind IPs.
+- `inline-selector` uses one shared host IP in every exposure mode because route selection moves to the proxy username.
 
 ## Setup examples
 
@@ -142,6 +144,31 @@ In that posture:
 - direct host-IP entrypoints are the intended access path
 - `mullgate proxy access` is still useful for local-only hostname testing, but it is no longer required for remote clients
 
+### Example: private-network inline-selector access
+
+Use this when trusted-network clients should connect to one shared host and select the Mullvad exit inline in the proxy username:
+
+```bash
+export MULLGATE_ACCOUNT_NUMBER=123456789012
+export MULLGATE_PROXY_USERNAME=alice
+export MULLGATE_PROXY_PASSWORD=''
+export MULLGATE_LOCATIONS=sweden-gothenburg,austria-vienna
+export MULLGATE_EXPOSURE_MODE=private-network
+export MULLGATE_BIND_HOST=100.124.44.113
+
+mullgate setup --non-interactive
+mullgate proxy access --access-mode inline-selector
+```
+
+What to expect:
+
+- one shared SOCKS5 listener and one shared HTTP listener on the trusted-network host
+- selector examples such as `socks5://se:@100.124.44.113:1080` and `socks5://se-got:@100.124.44.113:1080`
+- exact relay selectors when the user wants a specific server, for example `socks5://se-got-wg-101:@100.124.44.113:1080`
+- `mullgate proxy export` does not emit route URLs in `inline-selector` mode
+
+Use the guaranteed `scheme://selector:@host:port` form. The shorter `scheme://selector@host:port` form is best-effort only because some clients treat a missing password inconsistently.
+
 ## Unsupported local config versions
 
 The current CLI only operates on the current v2 config/runtime shape.
@@ -158,6 +185,8 @@ Do not expect the current CLI to keep operating on an older runtime bundle in pl
 ## Exporting proxy lists for clients
 
 Use `mullgate proxy export` when you want a ready-to-paste inventory of authenticated route URLs instead of assembling client config by hand.
+
+`mullgate proxy export` currently supports `published-routes` mode only. If the saved access mode is `inline-selector`, use `mullgate proxy access` to inspect the shared listener and selector examples instead.
 
 ### Discover the curated region groups
 
@@ -268,10 +297,10 @@ Use it when:
 
 ## Hostname and direct-IP access
 
-Mullgate exposes the same per-route listeners in two parallel forms:
+Mullgate exposes proxy entrypoints in two access models:
 
-- **hostname entrypoints** — route-aware names such as `sweden-gothenburg`, `austria-vienna`, or `sweden-gothenburg.proxy.example.com`
-- **direct-IP entrypoints** — the bind IP for each route, such as `127.0.0.1`, `127.0.0.2`, or `192.168.10.10`
+- **published-routes** — route-aware hostnames or per-route ports such as `sweden-gothenburg.proxy.example.com:1080` or `100.124.44.113:1081`
+- **inline-selector** — one shared listener per protocol, with the selector in the username such as `socks5://se:@100.124.44.113:1080`
 
 ### When hostname access works
 
@@ -287,12 +316,14 @@ In loopback mode without a base domain, those hostname mappings are optional. Di
 
 ### Why the mapping matters for multi-route proof
 
-Mullgate's routing layer dispatches by **destination bind IP**, not by a late application-level hint. That means:
+Mullgate's routing layer uses the access mode you chose:
 
-- every remote route needs its own bind IP
-- hostname proof only works when name resolution lands on the correct IP first
-- if two hostnames resolve to the same bind IP, they collapse to the same route
-- in DNS-backed or non-loopback hostname setups, `mullgate proxy doctor` reports hostname drift and points you back to `mullgate proxy access`
+- in `published-routes + loopback`, route selection still happens by destination bind IP
+- in `published-routes + private-network`, routes can share one host IP because each route gets its own published port
+- in `published-routes + public`, each route still needs its own bind IP
+- in `inline-selector`, routes share one listener and the username selector chooses the backend
+
+Hostname proof still depends on correct name resolution. If the configured hostname points at the wrong host IP, `mullgate proxy doctor` reports hostname drift and points you back to `mullgate proxy access`.
 
 ### Example `curl` forms
 
@@ -316,7 +347,7 @@ curl \
 
 If HTTPS proxy support is configured with a cert, key, and HTTPS port, the same route inventory appears in `mullgate proxy access`, `start`, `status`, and `runtime-manifest.json`.
 
-## Editing exposure after setup
+## Editing access and exposure after setup
 
 Use `mullgate proxy access` instead of editing JSON by hand.
 
@@ -329,10 +360,12 @@ mullgate proxy access
 The report includes:
 
 - mode (`loopback`, `private-network`, or `public`)
+- access mode (`published-routes` or `inline-selector`)
 - base domain and whether LAN access is expected
-- per-route hostname and bind IP inventory
+- the shared host or per-route hostname and bind IP inventory
 - DNS guidance when a base domain is set
-- hostname and direct-IP listener URLs with full credentials, ready to copy
+- hostname and direct-IP listener URLs with full credentials in `published-routes`
+- selector syntax and selector examples in `inline-selector`
 - whether the current runtime state needs a restart or refresh
 
 ### Update the posture
@@ -343,8 +376,7 @@ Example: switch from loopback to private-network hostnames:
 mullgate proxy access \
   --mode private-network \
   --base-domain proxy.example.com \
-  --route-bind-ip 192.168.10.10 \
-  --route-bind-ip 192.168.10.11
+  --route-bind-ip 100.124.44.113
 ```
 
 Example: switch to direct-IP public exposure:
@@ -356,6 +388,23 @@ mullgate proxy access \
   --route-bind-ip 203.0.113.10 \
   --route-bind-ip 203.0.113.11
 ```
+
+Example: switch the same private-network host to selector-driven access:
+
+```bash
+mullgate proxy access \
+  --mode private-network \
+  --access-mode inline-selector \
+  --route-bind-ip 100.124.44.113
+```
+
+If you intentionally expose `inline-selector` on a public host with an empty password, add:
+
+```bash
+--unsafe-public-empty-password
+```
+
+Without that explicit override, Mullgate blocks `public + inline-selector + empty password`.
 
 After an exposure edit, Mullgate marks the runtime state as `unvalidated`. Do one of these before trusting the saved and runtime surfaces again:
 

--- a/docs/mullgate-docs/content/docs/reference/commands.mdx
+++ b/docs/mullgate-docs/content/docs/reference/commands.mdx
@@ -16,8 +16,8 @@ The documentation repeatedly anchors itself to the following CLI help contract:
 | command | key flags | purpose |
 | --- | --- | --- |
 | `mullgate setup` | `--non-interactive`, `--location`, `--exposure-mode` | create or update canonical config and derived runtime artifacts |
-| `mullgate proxy access` | `--mode`, `--base-domain`, `--route-bind-ip` | inspect or update hostnames, bind IPs, DNS guidance, and direct-IP entrypoints |
-| `mullgate proxy export` | `--regions`, `--guided`, selector flags | list region groups or generate client-ready proxy inventories |
+| `mullgate proxy access` | `--mode`, `--access-mode`, `--base-domain`, `--route-bind-ip`, `--unsafe-public-empty-password` | inspect or update exposure posture, access mode, host planning, DNS guidance, selector examples, and direct-IP entrypoints |
+| `mullgate proxy export` | `--regions`, `--guided`, selector flags | list region groups or generate client-ready proxy inventories in `published-routes` mode |
 | `mullgate proxy relay list` | selector flags such as `--country`, `--owner`, `--provider` | inspect relay candidates that match a policy |
 | `mullgate proxy relay probe` | `--country`, `--count` | latency-probe likely relay candidates |
 | `mullgate proxy relay recommend` | `--country`, `--count`, `--apply` | preview or pin an exact relay choice |
@@ -45,8 +45,8 @@ A practical workflow usually looks like this:
 
 1. `mullgate setup`
 2. `mullgate proxy access`
-3. `mullgate proxy export --regions`
-4. `mullgate proxy export --guided`
+3. if you want a proxy inventory file, `mullgate proxy export --regions`
+4. if you want a proxy inventory file, `mullgate proxy export --guided`
 5. `mullgate proxy relay list`
 6. `mullgate proxy relay probe`
 7. `mullgate proxy relay recommend`
@@ -55,6 +55,8 @@ A practical workflow usually looks like this:
 10. `mullgate proxy start`
 11. `mullgate proxy status`
 12. `mullgate proxy doctor`
+
+If you switch to `inline-selector`, skip `mullgate proxy export` and use `mullgate proxy access` to inspect the shared listener and selector examples.
 
 ## Reference practice
 

--- a/docs/mullgate-docs/content/docs/reference/configuration.mdx
+++ b/docs/mullgate-docs/content/docs/reference/configuration.mdx
@@ -13,8 +13,9 @@ Required non-interactive setup inputs include:
 
 - Mullvad account number
 - proxy username
-- proxy password
 - one or more route locations
+
+The proxy password is optional. If you omit it, Mullgate saves an empty password.
 
 ### Routing inventory
 
@@ -29,11 +30,13 @@ That route inventory is what drives:
 
 ### Exposure configuration
 
-Exposure settings define how routes are reachable.
+Exposure and access settings define how routes are reachable and how clients choose them.
 
 Key inputs include:
 
 - exposure mode
+- access mode
+- `allowUnsafePublicEmptyPassword`
 - base domain
 - bind host
 - per-route bind IPs
@@ -81,8 +84,9 @@ The usage guide documents these variables:
 - `MULLGATE_LOCATION` is shorthand for route 1
 - `MULLGATE_LOCATIONS` is ordered and comma-separated
 - `MULLGATE_ROUTE_BIND_IPS` is ordered and comma-separated
-- non-loopback exposure requires one explicit bind IP per routed location
-- multi-route non-loopback exposure requires distinct bind IPs
+- `private-network` uses one shared trusted-network host IP
+- `public + published-routes` requires one explicit bind IP per routed location, and multi-route public exposure requires distinct bind IPs
+- `inline-selector` uses one shared host because route selection moves to the username
 - CLI commands are the preferred way to mutate configuration state
 
 ## Operational guidance
@@ -92,6 +96,6 @@ Change configuration through Mullgate CLI commands where possible instead of edi
 For operators, the important validation loop is:
 
 1. inspect with `mullgate proxy access`
-2. review hostnames with `mullgate proxy access`
+2. review hostnames or selector examples with `mullgate proxy access`
 3. refresh derived state with `mullgate proxy validate --refresh`
 4. confirm runtime with `mullgate proxy status` and `mullgate proxy doctor`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -43,7 +43,6 @@ Use Linux for the full setup/runtime/probe workflow. On macOS and Windows, treat
 | --- | --- | --- |
 | Mullvad account number | `--account-number <digits>` | `MULLGATE_ACCOUNT_NUMBER` |
 | Proxy username | `--username <name>` | `MULLGATE_PROXY_USERNAME` |
-| Proxy password | `--password <secret>` | `MULLGATE_PROXY_PASSWORD` |
 | One or more routed locations | `--location <alias>` (repeatable) | `MULLGATE_LOCATION` or `MULLGATE_LOCATIONS` |
 
 ### Common optional inputs
@@ -55,6 +54,7 @@ Use Linux for the full setup/runtime/probe workflow. On macOS and Windows, treat
 | Per-route bind IPs | `--route-bind-ip <ip>` (repeatable) | `MULLGATE_ROUTE_BIND_IPS` |
 | Exposure mode | `--exposure-mode <mode>` | `MULLGATE_EXPOSURE_MODE` |
 | Base domain | `--base-domain <domain>` | `MULLGATE_EXPOSURE_BASE_DOMAIN` |
+| Proxy password | `--password <secret>` | `MULLGATE_PROXY_PASSWORD` |
 | SOCKS5 port | `--socks-port <port>` | `MULLGATE_SOCKS_PORT` |
 | HTTP port | `--http-port <port>` | `MULLGATE_HTTP_PORT` |
 | HTTPS port | `--https-port <port>` | `MULLGATE_HTTPS_PORT` |
@@ -68,8 +68,10 @@ Notes:
 - `MULLGATE_LOCATION` is shorthand for route 1.
 - `MULLGATE_LOCATIONS` is the ordered, comma-separated form for multi-route setup.
 - `MULLGATE_ROUTE_BIND_IPS` is also ordered and comma-separated.
-- Non-loopback exposure requires one explicit bind IP per routed location.
-- Multi-route non-loopback exposure requires **distinct** bind IPs.
+- If you omit `MULLGATE_PROXY_PASSWORD`, setup saves an empty password.
+- `private-network` uses one shared trusted-network host IP. If Tailscale is available during setup and you do not override it, Mullgate should default to the host's `100.x` address.
+- `public` plus the default `published-routes` access mode still requires one explicit bind IP per routed location, and multi-route public exposure still requires **distinct** bind IPs.
+- `inline-selector` uses one shared host IP in every exposure mode because route selection moves into the proxy username.
 
 ## Setup examples
 
@@ -105,8 +107,8 @@ export MULLGATE_ACCOUNT_NUMBER=123456789012
 export MULLGATE_PROXY_USERNAME=alice
 export MULLGATE_PROXY_PASSWORD='replace-me'
 export MULLGATE_LOCATIONS=sweden-gothenburg,austria-vienna
-export MULLGATE_ROUTE_BIND_IPS=192.168.10.10,192.168.10.11
 export MULLGATE_EXPOSURE_MODE=private-network
+export MULLGATE_BIND_HOST=100.124.44.113
 export MULLGATE_EXPOSURE_BASE_DOMAIN=proxy.example.com
 
 mullgate setup --non-interactive
@@ -116,8 +118,10 @@ mullgate proxy access
 What to expect:
 
 - route hostnames become `sweden-gothenburg.proxy.example.com` and `austria-vienna.proxy.example.com`
+- both hostnames resolve to the same shared private-network host IP
+- route 1 keeps the base ports, and later routes move to the next ports (`1081`, `8081`, and `8444` when HTTPS is enabled)
 - `mullgate proxy access` prints the DNS A records operators must publish
-- each hostname must resolve to its own bind IP before hostname-based routing proof can work remotely
+- each hostname must resolve to that shared host IP before hostname-based routing proof can work remotely
 
 ### Example: direct-IP exposure with no base domain
 
@@ -127,15 +131,46 @@ If you do not set a base domain in `private-network` or `public` mode, Mullgate 
 mullgate proxy access \
   --mode private-network \
   --clear-base-domain \
-  --route-bind-ip 192.168.10.10 \
-  --route-bind-ip 192.168.10.11
+  --route-bind-ip 100.124.44.113
 ```
 
 In that posture:
 
 - there are no DNS records to publish
-- direct bind-IP entrypoints are the intended access path
+- direct host-IP entrypoints are the intended access path
 - `mullgate proxy access` is still useful for local-only hostname testing, but it is no longer required for remote clients
+
+### Example: private-network inline-selector access
+
+Use this when trusted-network clients should connect to one shared host and select the Mullvad exit inline in the proxy username:
+
+```bash
+export MULLGATE_ACCOUNT_NUMBER=123456789012
+export MULLGATE_PROXY_USERNAME=alice
+export MULLGATE_PROXY_PASSWORD=''
+export MULLGATE_LOCATIONS=sweden-gothenburg,austria-vienna
+export MULLGATE_EXPOSURE_MODE=private-network
+export MULLGATE_BIND_HOST=100.124.44.113
+
+mullgate setup --non-interactive
+mullgate proxy access --access-mode inline-selector
+```
+
+What to expect:
+
+- the access report changes from per-route entrypoints to one shared host plus selector examples
+- the guaranteed syntax is `scheme://selector:@host:port`
+- the shorter `scheme://selector@host:port` form is best-effort only
+- selectors can refer to countries, country-city pairs, or exact relay hostnames such as `se`, `se-got`, or `se-got-wg-101`
+- `mullgate proxy export` does not emit route URLs in `inline-selector` mode
+
+Example client URLs:
+
+```text
+socks5://se:@100.124.44.113:1080
+socks5://se-got:@100.124.44.113:1080
+socks5://se-got-wg-101:@100.124.44.113:1080
+```
 
 ## Unsupported local config versions
 
@@ -260,7 +295,7 @@ curl \
 
 If HTTPS proxy support is configured with a cert, key, and HTTPS port, the same route inventory appears in `exposure`, `start`, `status`, and `runtime-manifest.json`.
 
-## Editing exposure after setup
+## Editing access and exposure after setup
 
 Use `mullgate proxy access` instead of editing JSON by hand.
 
@@ -273,10 +308,12 @@ mullgate proxy access
 The report includes:
 
 - mode (`loopback`, `private-network`, or `public`)
+- access mode (`published-routes` or `inline-selector`)
 - base domain and whether LAN access is expected
-- per-route hostname and bind IP inventory
+- the shared host or per-route hostname and bind IP inventory
 - DNS guidance when a base domain is set
-- hostname and direct-IP listener URLs with full authenticated values
+- hostname and direct-IP listener URLs with full authenticated values in `published-routes`
+- selector syntax and selector examples in `inline-selector`
 - whether the current runtime state needs a restart/refresh
 
 ### Update the posture
@@ -287,8 +324,7 @@ Example: switch from loopback to private-network hostnames:
 mullgate proxy access \
   --mode private-network \
   --base-domain proxy.example.com \
-  --route-bind-ip 192.168.10.10 \
-  --route-bind-ip 192.168.10.11
+  --route-bind-ip 100.124.44.113
 ```
 
 Example: switch to direct-IP public exposure:
@@ -300,6 +336,23 @@ mullgate proxy access \
   --route-bind-ip 203.0.113.10 \
   --route-bind-ip 203.0.113.11
 ```
+
+Example: switch the same private-network host to selector-driven access:
+
+```bash
+mullgate proxy access \
+  --mode private-network \
+  --access-mode inline-selector \
+  --route-bind-ip 100.124.44.113
+```
+
+If you intentionally expose `inline-selector` on a public host with an empty password, add:
+
+```bash
+--unsafe-public-empty-password
+```
+
+Without that explicit override, Mullgate blocks `public + inline-selector + empty password`.
 
 After an exposure edit, Mullgate marks the runtime state as `unvalidated`. Do one of these before trusting the saved/runtime surfaces again:
 

--- a/scripts/verify-m002-final.ts
+++ b/scripts/verify-m002-final.ts
@@ -407,6 +407,10 @@ function createExposureFixtureConfig(): MullgateConfig {
         username: 'alice',
         password: 'redacted-secret',
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: 'private-network',
         allowLan: true,

--- a/scripts/verify-m002-network-modes.ts
+++ b/scripts/verify-m002-network-modes.ts
@@ -386,6 +386,10 @@ function createBaseFixtureConfig(input: { readonly env: NodeJS.ProcessEnv }): Mu
         username: 'alice',
         password: 'multi-route-secret',
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: 'loopback',
         allowLan: false,

--- a/scripts/verify-m002-platform-surfaces.ts
+++ b/scripts/verify-m002-platform-surfaces.ts
@@ -400,6 +400,10 @@ function createFixtureConfig(input: { readonly env: NodeJS.ProcessEnv }): Mullga
         username: 'alice',
         password: 'platform-surface-secret',
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: 'loopback',
         allowLan: false,

--- a/scripts/verify-s04-exposure.ts
+++ b/scripts/verify-s04-exposure.ts
@@ -822,6 +822,10 @@ function createBaseFixtureConfig(env: NodeJS.ProcessEnv): MullgateConfig {
         username: 'alice',
         password: 'multi-route-secret',
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: 'loopback',
         allowLan: false,

--- a/scripts/verify-s05-diagnostics.ts
+++ b/scripts/verify-s05-diagnostics.ts
@@ -665,6 +665,10 @@ function createFixtureConfig(
         username: 'alice',
         password: 'multi-route-secret',
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: 'loopback',
         allowLan: false,

--- a/src/app/setup-runner.ts
+++ b/src/app/setup-runner.ts
@@ -1377,7 +1377,13 @@ function finalizeSetupValues(values: Partial<RawSetupInputValues>): SetupInputVa
   const username = values.username?.trim();
   const password = values.password?.trim();
 
-  if (!accountNumber || !bindHost || socksPort === undefined || httpPort === undefined || !username) {
+  if (
+    !accountNumber ||
+    !bindHost ||
+    socksPort === undefined ||
+    httpPort === undefined ||
+    !username
+  ) {
     throw new Error('Setup values are incomplete. Missing one or more required setup inputs.');
   }
 

--- a/src/app/setup-runner.ts
+++ b/src/app/setup-runner.ts
@@ -420,6 +420,10 @@ export async function runSetupFlow(options: RunSetupFlowOptions = {}): Promise<S
     routeProxyConfigPath: renderResult.artifactPaths.routeProxyConfigPath,
     routeProxyConfigText: renderResult.routeProxyConfig,
     routes: renderResult.routes,
+    inlineSelectors: renderResult.inlineSelectors,
+    accessMode: initialConfig.setup.access.mode,
+    exposureMode: initialConfig.setup.exposure.mode,
+    bindHost: initialConfig.setup.bind.host,
     bind: {
       socksPort: setupInputs.socksPort,
       httpPort: setupInputs.httpPort,
@@ -985,6 +989,10 @@ function createCanonicalConfig(input: {
         username: input.inputs.username,
         password: input.inputs.password,
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: input.inputs.exposureMode,
         allowLan: input.inputs.exposureMode !== 'loopback',
@@ -1130,8 +1138,6 @@ async function collectSetupInputs(input: {
   const proxyPassword = await password({
     message: 'Proxy password',
     mask: '•',
-    validate: (value) =>
-      (value ?? '').trim().length > 0 ? undefined : 'Proxy password is required.',
   });
 
   if (isCancel(proxyPassword)) {
@@ -1371,14 +1377,7 @@ function finalizeSetupValues(values: Partial<RawSetupInputValues>): SetupInputVa
   const username = values.username?.trim();
   const password = values.password?.trim();
 
-  if (
-    !accountNumber ||
-    !bindHost ||
-    socksPort === undefined ||
-    httpPort === undefined ||
-    !username ||
-    !password
-  ) {
+  if (!accountNumber || !bindHost || socksPort === undefined || httpPort === undefined || !username) {
     throw new Error('Setup values are incomplete. Missing one or more required setup inputs.');
   }
 
@@ -1396,7 +1395,7 @@ function finalizeSetupValues(values: Partial<RawSetupInputValues>): SetupInputVa
     socksPort,
     httpPort,
     username,
-    password,
+    password: password ?? '',
     locations,
     location: locations[0],
     httpsPort: values.httpsPort ?? null,

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1174,12 +1174,12 @@ export function updateExposureConfig(
     (nextAccessMode === 'inline-selector'
       ? [config.setup.bind.host]
       : nextMode === 'loopback'
-      ? []
-      : nextMode === 'private-network'
-        ? [config.setup.bind.host]
-        : config.setup.exposure.mode === 'loopback' && input.mode !== undefined
-          ? []
-          : existingBindIps);
+        ? []
+        : nextMode === 'private-network'
+          ? [config.setup.bind.host]
+          : config.setup.exposure.mode === 'loopback' && input.mode !== undefined
+            ? []
+            : existingBindIps);
   const validated = validateExposureSettings({
     routeCount: config.routing.locations.length,
     exposureMode: nextMode,

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -30,10 +30,11 @@ import {
   deriveRuntimeListenerHost,
   type ExposureValidationFailure,
   normalizeExposureBaseDomain,
+  validateAccessSettings,
   validateExposureSettings,
 } from '../config/exposure-contract.js';
 import { formatRedactedConfig } from '../config/redact.js';
-import type { ExposureMode, MullgateConfig } from '../config/schema.js';
+import type { AccessMode, ExposureMode, MullgateConfig } from '../config/schema.js';
 import { ConfigStore, type LoadConfigResult, normalizeMullgateConfig } from '../config/store.js';
 import { createLocationAliasCatalog, normalizeLocationToken } from '../domain/location-aliases.js';
 import {
@@ -50,6 +51,7 @@ import { buildPlatformSupportContract } from '../platform/support-contract.js';
 import { requireArrayValue, requireDefined } from '../required.js';
 import {
   ENTRY_WIREPROXY_SOCKS_PORT,
+  type InlineSelectorMapping,
   renderRuntimeProxyArtifacts,
 } from '../runtime/render-runtime-proxies.js';
 import { validateRuntimeArtifacts } from '../runtime/validate-runtime.js';
@@ -61,7 +63,9 @@ const EDITABLE_CONFIG_FIELDS = new Map<string, EditableFieldSpec>([
   ['setup.bind.httpPort', { parse: parsePort }],
   ['setup.bind.httpsPort', { parse: parseNullablePort }],
   ['setup.auth.username', { parse: parseRequiredString }],
-  ['setup.auth.password', { parse: parseRequiredString, secret: true }],
+  ['setup.auth.password', { parse: parseMaybeEmptyString, secret: true }],
+  ['setup.access.mode', { parse: parseAccessMode }],
+  ['setup.access.allowUnsafePublicEmptyPassword', { parse: parseBoolean }],
   ['setup.location.requested', { parse: parseRequiredString }],
   ['setup.location.country', { parse: parseNullableString }],
   ['setup.location.city', { parse: parseNullableString }],
@@ -112,6 +116,8 @@ type ConfigValidationResult = ConfigValidationSuccess | ConfigValidationFailure;
 
 type ExposureUpdateInput = {
   readonly mode?: ExposureMode;
+  readonly accessMode?: AccessMode;
+  readonly allowUnsafePublicEmptyPassword?: boolean;
   readonly baseDomain?: string | null;
   readonly baseDomainSpecified: boolean;
   readonly routeBindIps?: readonly string[];
@@ -128,6 +134,8 @@ type ExposureUpdateResult = ExposureUpdateSuccess | ExposureUpdateFailure;
 
 export type ExposureCommandOptions = {
   readonly mode?: string;
+  readonly accessMode?: string;
+  readonly unsafePublicEmptyPassword?: boolean;
   readonly baseDomain?: string;
   readonly clearBaseDomain?: boolean;
   readonly routeBindIp?: string[];
@@ -1058,6 +1066,48 @@ export function renderHostsReport(config: MullgateConfig, configPath: string): s
 export function renderExposureReport(config: MullgateConfig, configPath: string): string {
   const exposure = buildExposureContract(config);
 
+  if (exposure.accessMode === 'inline-selector' && exposure.inlineSelector) {
+    return [
+      'Mullgate exposure report',
+      'phase: inspect-config',
+      'source: canonical-config',
+      `config: ${configPath}`,
+      `mode: ${exposure.mode}`,
+      `access mode: ${exposure.accessMode}`,
+      `mode label: ${exposure.posture.modeLabel}`,
+      `recommendation: ${exposure.posture.recommendation}`,
+      `posture summary: ${exposure.posture.summary}`,
+      `remote story: ${exposure.posture.remoteStory}`,
+      `base domain: ${exposure.baseDomain ?? 'n/a'}`,
+      `allow lan: ${exposure.allowLan ? 'yes' : 'no'}`,
+      `shared host: ${exposure.inlineSelector.sharedHost}`,
+      `selector field: ${exposure.inlineSelector.selectorField}`,
+      `guaranteed syntax: ${exposure.inlineSelector.syntax.guaranteed}`,
+      `best-effort syntax: ${exposure.inlineSelector.syntax.bestEffort}`,
+      `runtime status: ${exposure.runtimeStatus.phase}`,
+      `restart needed: ${exposure.runtimeStatus.restartRequired ? 'yes' : 'no'}`,
+      ...(exposure.runtimeStatus.message
+        ? [`runtime message: ${exposure.runtimeStatus.message}`]
+        : []),
+      '',
+      'guidance',
+      ...exposure.guidance.map((line) => `- ${line}`),
+      '',
+      'selector examples',
+      ...exposure.inlineSelector.examples.flatMap((example, index) => [
+        `${index + 1}. ${example.targetLabel}`,
+        `   selector: ${example.selector}`,
+        `   guaranteed: ${redactInlineSelectorUrl(example.guaranteedUrl)}`,
+        `   best effort: ${example.bestEffortUrl}`,
+      ]),
+      '',
+      'warnings',
+      ...(exposure.warnings.length > 0
+        ? exposure.warnings.map((warning) => `- ${warning.severity}: ${warning.message}`)
+        : ['- none']),
+    ].join('\n');
+  }
+
   return [
     'Mullgate exposure report',
     'phase: inspect-config',
@@ -1112,13 +1162,18 @@ export function updateExposureConfig(
   input: ExposureUpdateInput,
 ): ExposureUpdateResult {
   const nextMode = input.mode ?? config.setup.exposure.mode;
+  const nextAccessMode = input.accessMode ?? config.setup.access.mode;
+  const nextAllowUnsafePublicEmptyPassword =
+    input.allowUnsafePublicEmptyPassword ?? config.setup.access.allowUnsafePublicEmptyPassword;
   const nextBaseDomain = input.baseDomainSpecified
     ? (input.baseDomain ?? null)
     : config.setup.exposure.baseDomain;
   const existingBindIps = config.routing.locations.map((location) => location.bindIp);
   const routeBindIps =
     input.routeBindIps ??
-    (nextMode === 'loopback'
+    (nextAccessMode === 'inline-selector'
+      ? [config.setup.bind.host]
+      : nextMode === 'loopback'
       ? []
       : nextMode === 'private-network'
         ? [config.setup.bind.host]
@@ -1128,6 +1183,7 @@ export function updateExposureConfig(
   const validated = validateExposureSettings({
     routeCount: config.routing.locations.length,
     exposureMode: nextMode,
+    accessMode: nextAccessMode,
     exposureBaseDomain: normalizeExposureBaseDomain(nextBaseDomain),
     routeBindIps,
     artifactPath,
@@ -1136,6 +1192,18 @@ export function updateExposureConfig(
 
   if (!validated.ok) {
     return validated;
+  }
+
+  const accessValidation = validateAccessSettings({
+    exposureMode: validated.mode,
+    accessMode: nextAccessMode,
+    password: config.setup.auth.password,
+    allowUnsafePublicEmptyPassword: nextAllowUnsafePublicEmptyPassword,
+    artifactPath,
+  });
+
+  if (!accessValidation.ok) {
+    return accessValidation;
   }
 
   const updatedRoutingLocations = config.routing.locations.map((location, index) => ({
@@ -1163,6 +1231,10 @@ export function updateExposureConfig(
       bind: {
         ...config.setup.bind,
         host: validated.bindHost,
+      },
+      access: {
+        mode: nextAccessMode,
+        allowUnsafePublicEmptyPassword: nextAllowUnsafePublicEmptyPassword,
       },
       exposure: {
         mode: validated.mode,
@@ -1885,6 +1957,17 @@ export function buildProxyExportPlan(input: {
   readonly relayCatalog: MullvadRelayCatalog;
   readonly configPath: string;
 }): ProxyExportPlanResult {
+  if (input.config.setup.access.mode === 'inline-selector') {
+    return {
+      ok: false,
+      phase: 'export-proxies',
+      source: 'canonical-config',
+      message:
+        'Proxy export currently supports published-routes mode only. Inline-selector access uses one shared listener, so switch back to published-routes or use `mullgate proxy access` for selector examples.',
+      configPath: input.configPath,
+    };
+  }
+
   for (const selector of input.selectors) {
     if (selector.kind === 'region' && !resolveRegionCountryCodes(selector.value)) {
       return {
@@ -3188,6 +3271,10 @@ export async function ensureProxyExportRoutes(input: {
     routeProxyConfigPath: renderResult.artifactPaths.routeProxyConfigPath,
     routeProxyConfigText: renderResult.routeProxyConfig,
     routes: renderResult.routes,
+    inlineSelectors: renderResult.inlineSelectors,
+    accessMode: pendingConfig.setup.access.mode,
+    exposureMode: pendingConfig.setup.exposure.mode,
+    bindHost: pendingConfig.setup.bind.host,
     bind: {
       socksPort: pendingConfig.setup.bind.socksPort,
       httpPort: pendingConfig.setup.bind.httpPort,
@@ -3438,10 +3525,18 @@ function deriveAddedRouteBindIps(input: {
     };
   }
 
+  if (input.config.setup.access.mode === 'inline-selector') {
+    return {
+      ok: true,
+      routeBindIps: Array.from({ length: input.count }, () => input.config.setup.bind.host),
+    };
+  }
+
   if (input.config.setup.exposure.mode === 'loopback') {
     const exposure = validateExposureSettings({
       routeCount: input.config.routing.locations.length + input.count,
       exposureMode: 'loopback',
+      accessMode: input.config.setup.access.mode,
       exposureBaseDomain: input.config.setup.exposure.baseDomain,
       routeBindIps: [],
       artifactPath: input.configPath,
@@ -3482,6 +3577,7 @@ function deriveAddedRouteBindIps(input: {
   const validated = validateExposureSettings({
     routeCount: input.config.routing.locations.length + input.count,
     exposureMode: input.config.setup.exposure.mode,
+    accessMode: input.config.setup.access.mode,
     exposureBaseDomain: input.config.setup.exposure.baseDomain,
     routeBindIps: [
       ...input.config.routing.locations.map((location) => location.bindIp),
@@ -4165,6 +4261,7 @@ async function validateSavedConfig(input: {
   ]).then(([entryExists, routeProxyExists]) => entryExists && routeProxyExists);
   const shouldRefresh =
     input.refresh ||
+    loadResult.config.setup.access.mode === 'inline-selector' ||
     loadResult.config.runtime.status.phase === 'unvalidated' ||
     !hasExistingRuntimeArtifacts;
 
@@ -4172,6 +4269,7 @@ async function validateSavedConfig(input: {
   let entryWireproxyConfigText: string | undefined;
   let routeProxyConfigPath = input.store.paths.routeProxyConfigFile;
   let routeProxyConfigText: string | undefined;
+  let inlineSelectors: readonly InlineSelectorMapping[] = [];
   let refreshedArtifacts = false;
 
   if (shouldRefresh) {
@@ -4225,6 +4323,7 @@ async function validateSavedConfig(input: {
     entryWireproxyConfigText = renderResult.entryWireproxyConfig;
     routeProxyConfigPath = renderResult.artifactPaths.routeProxyConfigPath;
     routeProxyConfigText = renderResult.routeProxyConfig;
+    inlineSelectors = renderResult.inlineSelectors;
     refreshedArtifacts = true;
   } else {
     [entryWireproxyConfigText, routeProxyConfigText] = await Promise.all([
@@ -4239,6 +4338,10 @@ async function validateSavedConfig(input: {
     routeProxyConfigPath,
     routeProxyConfigText,
     routes: buildRuntimeValidationRoutes(loadResult.config),
+    inlineSelectors,
+    accessMode: loadResult.config.setup.access.mode,
+    exposureMode: loadResult.config.setup.exposure.mode,
+    bindHost: loadResult.config.setup.bind.host,
     bind: {
       socksPort: loadResult.config.setup.bind.socksPort,
       httpPort: loadResult.config.setup.bind.httpPort,
@@ -4581,6 +4684,10 @@ export function createAuthenticatedEndpointUrl(
   return `${protocol}://${encodeURIComponent(config.setup.auth.username)}:${encodeURIComponent(config.setup.auth.password)}@${authorityAndPath}`;
 }
 
+function redactInlineSelectorUrl(url: string): string {
+  return url.replace(/:\/\/([^:@]+):@/, '://$1:[redacted]@');
+}
+
 function buildProxyExportFilename(input: {
   readonly protocol: ProxyExportProtocol;
   readonly selectors: readonly ProxyExportSelector[];
@@ -4753,6 +4860,10 @@ function parseRequiredString(raw: string): string {
   return value;
 }
 
+function parseMaybeEmptyString(raw: string): string {
+  return raw.trim();
+}
+
 function parseNullableString(raw: string, options: { json: boolean }): string | null {
   if (options.json) {
     const parsed = JSON.parse(raw) as unknown;
@@ -4826,6 +4937,16 @@ function parseBoolean(raw: string, options: { json: boolean }): boolean {
   }
 
   throw new Error('Boolean values must be true or false.');
+}
+
+function parseAccessMode(raw: string): AccessMode {
+  const value = raw.trim();
+
+  if (value === 'published-routes' || value === 'inline-selector') {
+    return value;
+  }
+
+  throw new Error('Access mode must be published-routes or inline-selector.');
 }
 
 function parseStringArray(raw: string, options: { json: boolean }): string[] {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -577,7 +577,8 @@ function buildExposureCheck(config: MullgateConfig, exposure: ExposureContract):
 
 function buildBindCheck(config: MullgateConfig): DoctorCheck {
   const routeBindIps =
-    config.setup.exposure.mode === 'private-network' || config.setup.access.mode === 'inline-selector'
+    config.setup.exposure.mode === 'private-network' ||
+    config.setup.access.mode === 'inline-selector'
       ? [config.setup.bind.host]
       : config.routing.locations.map((location) => location.bindIp);
   const details = [
@@ -595,7 +596,10 @@ function buildBindCheck(config: MullgateConfig): DoctorCheck {
     );
   }
 
-  if (config.setup.exposure.mode === 'private-network' || config.setup.access.mode === 'inline-selector') {
+  if (
+    config.setup.exposure.mode === 'private-network' ||
+    config.setup.access.mode === 'inline-selector'
+  ) {
     for (const location of config.routing.locations) {
       if (location.bindIp !== config.setup.bind.host) {
         issues.push(
@@ -605,7 +609,10 @@ function buildBindCheck(config: MullgateConfig): DoctorCheck {
     }
   }
 
-  if (config.setup.exposure.mode === 'loopback' && config.setup.access.mode === 'published-routes') {
+  if (
+    config.setup.exposure.mode === 'loopback' &&
+    config.setup.access.mode === 'published-routes'
+  ) {
     for (const [index, location] of config.routing.locations.entries()) {
       const expected = deriveLoopbackBindIp(index);
       if (location.bindIp !== expected) {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -530,6 +530,7 @@ function buildExposureCheck(config: MullgateConfig, exposure: ExposureContract):
   const allowLanMismatch = config.setup.exposure.allowLan !== expectedAllowLan;
   const details = [
     `mode=${exposure.mode}`,
+    `access-mode=${exposure.accessMode}`,
     `mode-label=${exposure.posture.modeLabel}`,
     `recommendation=${exposure.posture.recommendation}`,
     `posture-summary=${exposure.posture.summary}`,
@@ -576,7 +577,7 @@ function buildExposureCheck(config: MullgateConfig, exposure: ExposureContract):
 
 function buildBindCheck(config: MullgateConfig): DoctorCheck {
   const routeBindIps =
-    config.setup.exposure.mode === 'private-network'
+    config.setup.exposure.mode === 'private-network' || config.setup.access.mode === 'inline-selector'
       ? [config.setup.bind.host]
       : config.routing.locations.map((location) => location.bindIp);
   const details = [
@@ -594,17 +595,17 @@ function buildBindCheck(config: MullgateConfig): DoctorCheck {
     );
   }
 
-  if (config.setup.exposure.mode === 'private-network') {
+  if (config.setup.exposure.mode === 'private-network' || config.setup.access.mode === 'inline-selector') {
     for (const location of config.routing.locations) {
       if (location.bindIp !== config.setup.bind.host) {
         issues.push(
-          `Route ${location.runtime.routeId} should reuse the shared private-network host ${config.setup.bind.host}, but saved config has ${location.bindIp}.`,
+          `Route ${location.runtime.routeId} should reuse the shared listener host ${config.setup.bind.host}, but saved config has ${location.bindIp}.`,
         );
       }
     }
   }
 
-  if (config.setup.exposure.mode === 'loopback') {
+  if (config.setup.exposure.mode === 'loopback' && config.setup.access.mode === 'published-routes') {
     for (const [index, location] of config.routing.locations.entries()) {
       const expected = deriveLoopbackBindIp(index);
       if (location.bindIp !== expected) {
@@ -617,6 +618,7 @@ function buildBindCheck(config: MullgateConfig): DoctorCheck {
     const validation = validateExposureSettings({
       routeCount: config.routing.locations.length,
       exposureMode: config.setup.exposure.mode,
+      accessMode: config.setup.access.mode,
       exposureBaseDomain: config.setup.exposure.baseDomain,
       routeBindIps,
       artifactPath: config.runtime.sourceConfigPath,

--- a/src/commands/proxy.ts
+++ b/src/commands/proxy.ts
@@ -1,7 +1,7 @@
 import type { Command } from 'commander';
 
 import { writeCliReport } from '../cli-output.js';
-import type { ExposureMode } from '../config/schema.js';
+import type { AccessMode, ExposureMode } from '../config/schema.js';
 import { ConfigStore } from '../config/store.js';
 import { registerAutostartCommand } from './autostart.js';
 import {
@@ -69,7 +69,15 @@ function registerProxyAccessCommand(target: Command): void {
   target
     .command('access')
     .option('--mode <mode>', 'Set exposure mode to loopback, private-network, or public.')
+    .option(
+      '--access-mode <mode>',
+      'Set access mode to published-routes or inline-selector.',
+    )
     .option('--base-domain <domain>', 'Set the base domain used to derive per-route hostnames.')
+    .option(
+      '--unsafe-public-empty-password',
+      'Allow empty passwords when inline-selector is exposed on a public host.',
+    )
     .option(
       '--clear-base-domain',
       'Remove any configured base domain and fall back to alias/direct-IP hostnames.',
@@ -135,9 +143,11 @@ function registerProxyAccessCommand(target: Command): void {
       }
 
       let mode: ExposureMode | undefined;
+      let accessMode: AccessMode | undefined;
 
       try {
         mode = options.mode ? parseExposureModeOption(options.mode) : undefined;
+        accessMode = options.accessMode ? parseAccessModeOption(options.accessMode) : undefined;
       } catch (error) {
         writeCliReport({
           sink: process.stderr,
@@ -156,6 +166,10 @@ function registerProxyAccessCommand(target: Command): void {
 
       const updateResult = updateExposureConfig(result.config, store.paths.configFile, {
         ...(mode ? { mode } : {}),
+        ...(accessMode ? { accessMode } : {}),
+        ...(options.unsafePublicEmptyPassword !== undefined
+          ? { allowUnsafePublicEmptyPassword: options.unsafePublicEmptyPassword }
+          : {}),
         ...(options.baseDomain !== undefined ? { baseDomain: options.baseDomain } : {}),
         baseDomainSpecified: Boolean(options.baseDomain !== undefined || options.clearBaseDomain),
         ...(options.clearBaseDomain ? { baseDomain: null } : {}),
@@ -237,6 +251,8 @@ function renderProxyAccessUpdateError(
 function hasAccessUpdate(options: ExposureCommandOptions): boolean {
   return Boolean(
     options.mode ||
+      options.accessMode ||
+      options.unsafePublicEmptyPassword !== undefined ||
       options.baseDomain !== undefined ||
       options.clearBaseDomain ||
       options.routeBindIp?.length,
@@ -251,6 +267,16 @@ function parseExposureModeOption(raw: string): ExposureMode {
   }
 
   throw new Error('Exposure mode must be loopback, private-network, or public.');
+}
+
+function parseAccessModeOption(raw: string): AccessMode {
+  const normalized = raw.trim();
+
+  if (normalized === 'published-routes' || normalized === 'inline-selector') {
+    return normalized;
+  }
+
+  throw new Error('Access mode must be published-routes or inline-selector.');
 }
 
 function collectRepeatedValues(value: string, previous: string[]): string[] {

--- a/src/commands/proxy.ts
+++ b/src/commands/proxy.ts
@@ -69,10 +69,7 @@ function registerProxyAccessCommand(target: Command): void {
   target
     .command('access')
     .option('--mode <mode>', 'Set exposure mode to loopback, private-network, or public.')
-    .option(
-      '--access-mode <mode>',
-      'Set access mode to published-routes or inline-selector.',
-    )
+    .option('--access-mode <mode>', 'Set access mode to published-routes or inline-selector.')
     .option('--base-domain <domain>', 'Set the base domain used to derive per-route hostnames.')
     .option(
       '--unsafe-public-empty-password',

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -268,6 +268,7 @@ export async function runStartFlow(
 
   const validationResult = await validateRenderedRuntime(
     {
+      config: baseConfig,
       renderResult: runtimeProxyRender,
       bind: baseConfig.setup.bind,
       reportPath: store.paths.runtimeValidationReportFile,
@@ -299,7 +300,7 @@ export async function runStartFlow(
     baseConfig,
     'starting',
     attemptedAt,
-    `Validated shared entry tunnel plus ${runtimeProxyRender.routes.length} routed exits via ${validationResult.validationSource}; launching Docker Compose from ${runtimeBundle.artifactPaths.dockerComposePath}.`,
+    `Validated shared entry tunnel plus ${baseConfig.routing.locations.length} configured routes via ${validationResult.validationSource}; launching Docker Compose from ${runtimeBundle.artifactPaths.dockerComposePath}.`,
   );
   const startingPersist = await persistConfigOnly(store, startingConfig);
 
@@ -407,7 +408,8 @@ export async function runStartFlow(
       'phase: compose-launch',
       'source: docker-compose',
       `attempted at: ${report.attemptedAt}`,
-      `routes: ${runtimeProxyRender.routes.length}`,
+      `routes: ${baseConfig.routing.locations.length}`,
+      `access mode: ${baseConfig.setup.access.mode}`,
       `config: ${store.paths.configFile}`,
       `entry wireproxy config: ${runtimeProxyRender.artifactPaths.entryWireproxyConfigPath}`,
       `route proxy config: ${runtimeProxyRender.artifactPaths.routeProxyConfigPath}`,
@@ -424,6 +426,30 @@ export async function runStartFlow(
 }
 
 function renderExposureInventory(manifest: RuntimeBundleManifest): string[] {
+  if (manifest.exposure.accessMode === 'inline-selector' && manifest.exposure.inlineSelector) {
+    return [
+      `mode: ${manifest.exposure.mode}`,
+      `access mode: ${manifest.exposure.accessMode}`,
+      `base domain: ${manifest.exposure.baseDomain ?? 'n/a'}`,
+      `shared host: ${manifest.exposure.inlineSelector.sharedHost}`,
+      `selector field: ${manifest.exposure.inlineSelector.selectorField}`,
+      `guaranteed syntax: ${manifest.exposure.inlineSelector.syntax.guaranteed}`,
+      `best-effort syntax: ${manifest.exposure.inlineSelector.syntax.bestEffort}`,
+      `restart needed: ${manifest.exposure.runtimeStatus.restartRequired ? 'yes' : 'no'}`,
+      'selector examples:',
+      ...manifest.exposure.inlineSelector.examples.flatMap((example, index) => [
+        `${index + 1}. ${example.targetLabel}`,
+        `   selector: ${example.selector}`,
+        `   guaranteed: ${redactInlineSelectorUrl(example.guaranteedUrl)}`,
+        `   best-effort: ${example.bestEffortUrl}`,
+      ]),
+      'warnings:',
+      ...(manifest.exposure.warnings.length > 0
+        ? manifest.exposure.warnings.map((warning) => `- ${warning.severity}: ${warning.message}`)
+        : ['- none']),
+    ];
+  }
+
   return [
     `mode: ${manifest.exposure.mode}`,
     `base domain: ${manifest.exposure.baseDomain ?? 'n/a'}`,
@@ -442,6 +468,10 @@ function renderExposureInventory(manifest: RuntimeBundleManifest): string[] {
       ? manifest.exposure.warnings.map((warning) => `- ${warning.severity}: ${warning.message}`)
       : ['- none']),
   ];
+}
+
+function redactInlineSelectorUrl(url: string): string {
+  return url.replace(/:\/\/([^:@]+):@/, '://$1:[redacted]@');
 }
 
 function writeStartResult(
@@ -525,6 +555,7 @@ function withStartOutcome(
 
 async function validateRenderedRuntime(
   input: {
+    readonly config: MullgateConfig;
     readonly renderResult: Awaited<ReturnType<typeof renderRuntimeProxyArtifacts>> & { ok: true };
     readonly bind: MullgateConfig['setup']['bind'];
     readonly reportPath: string;
@@ -538,6 +569,10 @@ async function validateRenderedRuntime(
     routeProxyConfigPath: input.renderResult.artifactPaths.routeProxyConfigPath,
     routeProxyConfigText: input.renderResult.routeProxyConfig,
     routes: input.renderResult.routes,
+    inlineSelectors: input.renderResult.inlineSelectors,
+    accessMode: input.renderResult.accessMode,
+    exposureMode: input.config.setup.exposure.mode,
+    bindHost: input.config.setup.bind.host,
     bind: {
       socksPort: input.bind.socksPort,
       httpPort: input.bind.httpPort,

--- a/src/config/exposure-contract.ts
+++ b/src/config/exposure-contract.ts
@@ -2,7 +2,7 @@ import { isIP } from 'node:net';
 
 import { requireDefined } from '../required.js';
 import { REDACTED } from './redact.js';
-import type { ExposureMode, MullgateConfig } from './schema.js';
+import type { AccessMode, ExposureMode, MullgateConfig } from './schema.js';
 
 const HTTPS_DEFAULT_PORT = 8443;
 const PRIVATE_NETWORK_LISTEN_HOST = '0.0.0.0';
@@ -55,24 +55,46 @@ export type ExposureRouteContract = {
   readonly endpoints: readonly ExposureEndpoint[];
 };
 
+export type InlineSelectorExample = {
+  readonly selector: string;
+  readonly targetLabel: string;
+  readonly endpoints: readonly ExposureEndpoint[];
+  readonly guaranteedUrl: string;
+  readonly bestEffortUrl: string;
+};
+
 export type ExposureWarning = {
   readonly code:
     | 'LOOPBACK_ONLY'
     | 'DNS_REQUIRED'
     | 'PUBLIC_EXPOSURE'
     | 'SINGLE_ROUTE'
-    | 'RUNTIME_UNVALIDATED';
+    | 'RUNTIME_UNVALIDATED'
+    | 'INLINE_SELECTOR_PUBLIC_EMPTY_PASSWORD';
   readonly severity: 'info' | 'warning';
   readonly message: string;
 };
 
 export type ExposureContract = {
   readonly mode: ExposureMode;
+  readonly accessMode: AccessMode;
   readonly allowLan: boolean;
   readonly baseDomain: string | null;
   readonly ports: readonly ExposurePort[];
   readonly routes: readonly ExposureRouteContract[];
   readonly dnsRecords: readonly string[];
+  readonly inlineSelector:
+    | null
+    | {
+        readonly sharedHost: string;
+        readonly listenerHost: string;
+        readonly selectorField: 'username';
+        readonly syntax: {
+          readonly guaranteed: string;
+          readonly bestEffort: string;
+        };
+        readonly examples: readonly InlineSelectorExample[];
+      };
   readonly posture: {
     readonly recommendation: 'local-default' | 'recommended-remote' | 'advanced-remote';
     readonly modeLabel: string;
@@ -93,12 +115,55 @@ export type ExposureContract = {
   };
 };
 
+export type AccessValidationResult =
+  | { readonly ok: true }
+  | ExposureValidationFailure;
+
 export function computePublishedPort(
   exposureMode: ExposureMode,
   basePort: number,
   routeIndex: number,
 ): number {
   return exposureMode === 'private-network' ? basePort + routeIndex : basePort;
+}
+
+export function usesInlineSelectorAccess(
+  config: Pick<MullgateConfig, 'setup'>,
+): boolean {
+  return config.setup.access.mode === 'inline-selector';
+}
+
+export function deriveInlineSelectorBindHost(config: Pick<MullgateConfig, 'setup'>): string {
+  return config.setup.bind.host;
+}
+
+export function validateAccessSettings(input: {
+  readonly exposureMode: ExposureMode;
+  readonly accessMode: AccessMode;
+  readonly password: string;
+  readonly allowUnsafePublicEmptyPassword: boolean;
+  readonly artifactPath: string;
+}): AccessValidationResult {
+  if (
+    input.exposureMode === 'public' &&
+    input.accessMode === 'inline-selector' &&
+    input.password.length === 0 &&
+    !input.allowUnsafePublicEmptyPassword
+  ) {
+    return {
+      ok: false,
+      phase: 'setup-validation',
+      source: 'input',
+      code: 'UNSAFE_PUBLIC_INLINE_SELECTOR_EMPTY_PASSWORD',
+      message:
+        'Public inline-selector access with an empty password is blocked unless the unsafe override is enabled.',
+      cause:
+        'Set setup.access.allowUnsafePublicEmptyPassword=true or choose a non-empty proxy password before exposing selector-driven listeners on a public host.',
+      artifactPath: input.artifactPath,
+    };
+  }
+
+  return { ok: true };
 }
 
 export function deriveRuntimeListenerHost(exposureMode: ExposureMode, bindIp: string): string {
@@ -111,20 +176,23 @@ export function deriveRuntimeBackendHost(exposureMode: ExposureMode, bindIp: str
 
 export function buildExposureContract(config: MullgateConfig): ExposureContract {
   const ports = collectExposurePorts(config);
-  const routes = config.routing.locations.map((route, index) => ({
-    index,
-    alias: route.alias,
-    routeId: route.runtime.routeId,
-    hostname: route.hostname,
-    bindIp: route.bindIp,
-    dnsRecord: config.setup.exposure.baseDomain ? `${route.hostname} A ${route.bindIp}` : null,
-    endpoints: ports.map((entry) =>
-      createExposureEndpoint(route.hostname, route.bindIp, {
-        ...entry,
-        port: computePublishedPort(config.setup.exposure.mode, entry.port, index),
-      }),
-    ),
-  }));
+  const inlineSelectorEnabled = usesInlineSelectorAccess(config);
+  const routes = inlineSelectorEnabled
+    ? []
+    : config.routing.locations.map((route, index) => ({
+        index,
+        alias: route.alias,
+        routeId: route.runtime.routeId,
+        hostname: route.hostname,
+        bindIp: route.bindIp,
+        dnsRecord: config.setup.exposure.baseDomain ? `${route.hostname} A ${route.bindIp}` : null,
+        endpoints: ports.map((entry) =>
+          createExposureEndpoint(route.hostname, route.bindIp, {
+            ...entry,
+            port: computePublishedPort(config.setup.exposure.mode, entry.port, index),
+          }),
+        ),
+      }));
   const dnsRecords = routes.flatMap((route) => (route.dnsRecord ? [route.dnsRecord] : []));
   const warnings: ExposureWarning[] = [];
 
@@ -174,13 +242,30 @@ export function buildExposureContract(config: MullgateConfig): ExposureContract 
     });
   }
 
+  if (
+    config.setup.exposure.mode === 'public' &&
+    inlineSelectorEnabled &&
+    config.setup.auth.password.length === 0
+  ) {
+    warnings.push({
+      code: 'INLINE_SELECTOR_PUBLIC_EMPTY_PASSWORD',
+      severity: 'warning',
+      message:
+        'Inline-selector access is exposing a public listener with an empty password. This is only appropriate when you intentionally accept selector-only proxy access on the public host.',
+    });
+  }
+
+  const inlineSelector = inlineSelectorEnabled ? buildInlineSelectorContract(config, ports) : null;
+
   return {
     mode: config.setup.exposure.mode,
+    accessMode: config.setup.access.mode,
     allowLan: config.setup.exposure.allowLan,
     baseDomain: config.setup.exposure.baseDomain,
     ports,
     routes,
     dnsRecords,
+    inlineSelector,
     posture: buildExposurePosture(config),
     guidance: buildExposureGuidance(config, dnsRecords),
     remediation: buildExposureRemediation(config),
@@ -196,12 +281,14 @@ export function buildExposureContract(config: MullgateConfig): ExposureContract 
 export function validateExposureSettings(input: {
   readonly routeCount: number;
   readonly exposureMode: ExposureMode;
+  readonly accessMode?: AccessMode;
   readonly exposureBaseDomain: string | null | undefined;
   readonly routeBindIps: readonly string[];
   readonly artifactPath: string;
   readonly caller?: 'setup' | 'config-exposure';
 }): ExposureValidationResult {
   const baseDomain = normalizeExposureBaseDomain(input.exposureBaseDomain);
+  const accessMode = input.accessMode ?? 'published-routes';
 
   if (baseDomain && !isValidBaseDomain(baseDomain)) {
     return {
@@ -214,7 +301,7 @@ export function validateExposureSettings(input: {
     };
   }
 
-  if (input.exposureMode === 'loopback') {
+  if (input.exposureMode === 'loopback' && accessMode === 'published-routes') {
     const routeBindIps = Array.from({ length: input.routeCount }, (_, index) =>
       deriveLoopbackBindIp(index),
     ) as [string, ...string[]];
@@ -228,18 +315,23 @@ export function validateExposureSettings(input: {
     };
   }
 
-  if (input.exposureMode === 'private-network') {
+  if (input.exposureMode === 'private-network' || accessMode === 'inline-selector') {
     if (input.routeBindIps.length !== 1) {
       return {
         ok: false,
         phase: 'setup-validation',
         source: 'input',
         code: 'BIND_IP_COUNT_MISMATCH',
-        message: `Private-network exposure publishes every route on one shared host IP, so exactly one bind IP is required, but received ${input.routeBindIps.length}.`,
+        message:
+          accessMode === 'inline-selector'
+            ? `Inline-selector access publishes one shared listener host, so exactly one bind IP is required, but received ${input.routeBindIps.length}.`
+            : `Private-network exposure publishes every route on one shared host IP, so exactly one bind IP is required, but received ${input.routeBindIps.length}.`,
         cause:
           input.caller === 'config-exposure'
             ? 'Pass exactly one --route-bind-ip <ip> for the shared host, or omit it to keep the saved host IP.'
-            : 'Pass one bind IP or set MULLGATE_ROUTE_BIND_IPS / --bind-host to the trusted-network host IP that remote clients should reach.',
+            : accessMode === 'inline-selector'
+              ? 'Pass one bind IP or set MULLGATE_ROUTE_BIND_IPS / --bind-host to the shared host that clients should reach for selector-driven access.'
+              : 'Pass one bind IP or set MULLGATE_ROUTE_BIND_IPS / --bind-host to the trusted-network host IP that remote clients should reach.',
         artifactPath: input.artifactPath,
       };
     }
@@ -255,20 +347,44 @@ export function validateExposureSettings(input: {
         phase: 'setup-validation',
         source: 'input',
         code: 'INVALID_BIND_IP',
-        message: `Private-network exposure requires one valid IPv4 host, but received ${bindHost}.`,
+        message:
+          accessMode === 'inline-selector'
+            ? `Inline-selector access requires one valid IPv4 host, but received ${bindHost}.`
+            : `Private-network exposure requires one valid IPv4 host, but received ${bindHost}.`,
         artifactPath: input.artifactPath,
       };
     }
 
-    if (!isPrivateNetworkHostIpv4(bindHost)) {
+    const invalidSharedHost =
+      input.exposureMode === 'loopback'
+        ? !isLoopbackIpv4(bindHost)
+        : input.exposureMode === 'public'
+          ? !isPublicExposureIpv4(bindHost)
+          : !isPrivateNetworkHostIpv4(bindHost);
+
+    if (invalidSharedHost) {
       return {
         ok: false,
         phase: 'setup-validation',
         source: 'input',
-        code: 'UNSAFE_PRIVATE_BIND_IP',
-        message: `Private-network exposure requires a trusted-network IPv4 host, but received ${bindHost}.`,
+        code:
+          input.exposureMode === 'public'
+            ? 'UNSAFE_PUBLIC_BIND_IP'
+            : input.exposureMode === 'loopback'
+              ? 'UNSAFE_LOOPBACK_BIND_IP'
+              : 'UNSAFE_PRIVATE_BIND_IP',
+        message:
+          input.exposureMode === 'public'
+            ? `Public inline-selector exposure requires a publicly routable IPv4 host, but received ${bindHost}.`
+            : input.exposureMode === 'loopback'
+              ? `Loopback inline-selector exposure requires a loopback IPv4 host, but received ${bindHost}.`
+              : `Private-network exposure requires a trusted-network IPv4 host, but received ${bindHost}.`,
         cause:
-          'Use an RFC1918 address, a Tailscale 100.x address, or 0.0.0.0 as the wildcard fallback when Tailscale is unavailable.',
+          input.exposureMode === 'public'
+            ? 'Choose one real public IPv4 address for the shared selector listener or switch to private-network / loopback exposure.'
+            : input.exposureMode === 'loopback'
+              ? 'Use a 127.x.y.z loopback host for same-machine selector access.'
+              : 'Use an RFC1918 address, a Tailscale 100.x address, or 0.0.0.0 as the wildcard fallback when Tailscale is unavailable.',
         artifactPath: input.artifactPath,
       };
     }
@@ -418,7 +534,90 @@ function createExposureEndpoint(
   };
 }
 
+function buildInlineSelectorContract(
+  config: MullgateConfig,
+  ports: readonly ExposurePort[],
+): NonNullable<ExposureContract['inlineSelector']> {
+  const sharedHost = deriveInlineSelectorBindHost(config);
+  const listenerHost = deriveRuntimeListenerHost(config.setup.exposure.mode, sharedHost);
+  const examples = createInlineSelectorExamples(config, ports, sharedHost);
+
+  return {
+    sharedHost,
+    listenerHost,
+    selectorField: 'username',
+    syntax: {
+      guaranteed: 'selector:@host:port',
+      bestEffort: 'selector@host:port',
+    },
+    examples,
+  };
+}
+
+function createInlineSelectorExamples(
+  config: MullgateConfig,
+  ports: readonly ExposurePort[],
+  sharedHost: string,
+): readonly InlineSelectorExample[] {
+  const resolveCountrySelector = (route: MullgateConfig['routing']['locations'][number]) =>
+    route.relayPreference.country ?? route.mullvad.exit.countryCode;
+  const resolveCitySelector = (route: MullgateConfig['routing']['locations'][number]) =>
+    route.relayPreference.city ?? route.mullvad.exit.cityCode;
+  const selectors = [
+    ...new Map(
+      config.routing.locations.flatMap((route) => {
+        const countrySelector = resolveCountrySelector(route);
+        const citySelector = resolveCitySelector(route);
+
+        return [
+          [
+            countrySelector,
+            {
+              selector: countrySelector,
+              targetLabel: `country ${countrySelector}`,
+            },
+          ],
+          [
+            `${countrySelector}-${citySelector}`,
+            {
+              selector: `${countrySelector}-${citySelector}`,
+              targetLabel: `city ${countrySelector}-${citySelector}`,
+            },
+          ],
+          [
+            route.mullvad.exit.relayHostname,
+            {
+              selector: route.mullvad.exit.relayHostname,
+              targetLabel: `relay ${route.mullvad.exit.relayHostname}`,
+            },
+          ],
+        ];
+      }),
+    ).values(),
+  ].slice(0, 3);
+
+  return selectors.map((entry) => ({
+    selector: entry.selector,
+    targetLabel: entry.targetLabel,
+    endpoints: ports.map((port) => createExposureEndpoint(sharedHost, sharedHost, port)),
+    guaranteedUrl: `${ports[0]?.protocol ?? 'socks5'}://${entry.selector}:@${sharedHost}:${ports[0]?.port ?? 0}`,
+    bestEffortUrl: `${ports[0]?.protocol ?? 'socks5'}://${entry.selector}@${sharedHost}:${ports[0]?.port ?? 0}`,
+  }));
+}
+
 function buildExposureGuidance(config: MullgateConfig, dnsRecords: readonly string[]): string[] {
+  if (usesInlineSelectorAccess(config)) {
+    const sharedHost = deriveInlineSelectorBindHost(config);
+
+    return [
+      'Inline-selector access keeps one shared listener per configured protocol and chooses the Mullvad exit from the proxy username instead of a pre-published per-route port.',
+      config.setup.exposure.mode === 'public'
+        ? 'Public inline-selector mode exposes one shared public listener. Only use this when you intentionally want remote selector-driven access on the public host.'
+        : `Clients should connect directly to ${sharedHost} and change the username to switch between country, city, and exact relay selectors.`,
+      'The guaranteed URL shape is `selector:@host:port`. The shorter `selector@host:port` form is best-effort only because some proxy clients do not normalize a missing password consistently.',
+    ];
+  }
+
   if (config.setup.exposure.mode === 'loopback') {
     return [
       'Loopback mode is the default local-only posture. Keep it for same-machine use and developer/operator checks.',
@@ -453,6 +652,39 @@ function buildExposureGuidance(config: MullgateConfig, dnsRecords: readonly stri
 }
 
 function buildExposurePosture(config: MullgateConfig): ExposureContract['posture'] {
+  if (usesInlineSelectorAccess(config)) {
+    if (config.setup.exposure.mode === 'loopback') {
+      return {
+        recommendation: 'local-default',
+        modeLabel: 'Loopback / inline selector',
+        summary:
+          'Same-machine selector-driven posture. One local listener per protocol accepts country, city, or relay selectors in the proxy username.',
+        remoteStory:
+          'Switch to private-network mode when other trusted-network machines should reach the same shared selector-driven listener.',
+      };
+    }
+
+    if (config.setup.exposure.mode === 'private-network') {
+      return {
+        recommendation: 'recommended-remote',
+        modeLabel: 'Private network / inline selector',
+        summary:
+          'Recommended remote selector-driven posture. One shared host IP and fixed ports let trusted-network clients choose the Mullvad exit inline.',
+        remoteStory:
+          'Other trusted-network machines connect to the shared host IP and change only the proxy username to switch country, city, or relay.',
+      };
+    }
+
+    return {
+      recommendation: 'advanced-remote',
+      modeLabel: 'Public / inline selector',
+      summary:
+        'Expert-only selector-driven public posture. One public listener accepts inline exit selection, so firewalling and explicit operator intent matter even more than in published-routes mode.',
+      remoteStory:
+        'Use this only when you intentionally want selector-driven access on a public listener and understand the authentication and exposure tradeoffs.',
+    };
+  }
+
   if (config.setup.exposure.mode === 'loopback') {
     return {
       recommendation: 'local-default',
@@ -486,6 +718,39 @@ function buildExposurePosture(config: MullgateConfig): ExposureContract['posture
 }
 
 function buildExposureRemediation(config: MullgateConfig): ExposureContract['remediation'] {
+  if (usesInlineSelectorAccess(config)) {
+    if (config.setup.exposure.mode === 'loopback') {
+      return {
+        bindPosture:
+          'Keep inline-selector loopback mode on one local bind host only. The shared listener should stay on 127.0.0.1 unless you intentionally switch exposure mode.',
+        hostnameResolution:
+          'Use the direct bind-host entrypoints for selector-driven access. Route hostnames are not the selector surface in this mode.',
+        restart:
+          'After changing access mode, exposure mode, or the bind host, rerun `mullgate proxy validate` or `mullgate proxy start` so the shared selector listeners are re-rendered.',
+      };
+    }
+
+    if (config.setup.exposure.mode === 'private-network') {
+      return {
+        bindPosture:
+          'Keep private-network inline-selector mode on one trusted-network host IP only. Mullgate binds wildcard listeners at runtime and uses the proxy username to choose exits.',
+        hostnameResolution:
+          'Use the direct shared host IP entrypoints unless you have your own DNS shortcut for that one shared listener host.',
+        restart:
+          'After changing access mode, exposure mode, or the bind host, rerun `mullgate proxy validate` or `mullgate proxy start` so the shared selector listeners are re-rendered.',
+      };
+    }
+
+    return {
+      bindPosture:
+        'Use public inline-selector mode only with one intentionally public bind IP. If you are not deliberately publishing one selector-driven listener, switch back to private-network or published-routes mode.',
+      hostnameResolution:
+        'Use the direct shared public host entrypoints unless you deliberately publish a DNS shortcut for that one listener host.',
+      restart:
+        'After changing access mode, exposure mode, or the bind host, rerun `mullgate proxy validate` or `mullgate proxy start` so the shared selector listeners are re-rendered.',
+    };
+  }
+
   if (config.setup.exposure.mode === 'loopback') {
     return {
       bindPosture:
@@ -556,6 +821,11 @@ function isPrivateIpv4(value: string): boolean {
     (first === 172 && second >= 16 && second <= 31) ||
     (first === 192 && second === 168)
   );
+}
+
+function isLoopbackIpv4(value: string): boolean {
+  const [first] = parseIpv4Octets(value);
+  return first === 127;
 }
 
 function isTailscaleIpv4(value: string): boolean {

--- a/src/config/exposure-contract.ts
+++ b/src/config/exposure-contract.ts
@@ -83,18 +83,16 @@ export type ExposureContract = {
   readonly ports: readonly ExposurePort[];
   readonly routes: readonly ExposureRouteContract[];
   readonly dnsRecords: readonly string[];
-  readonly inlineSelector:
-    | null
-    | {
-        readonly sharedHost: string;
-        readonly listenerHost: string;
-        readonly selectorField: 'username';
-        readonly syntax: {
-          readonly guaranteed: string;
-          readonly bestEffort: string;
-        };
-        readonly examples: readonly InlineSelectorExample[];
-      };
+  readonly inlineSelector: null | {
+    readonly sharedHost: string;
+    readonly listenerHost: string;
+    readonly selectorField: 'username';
+    readonly syntax: {
+      readonly guaranteed: string;
+      readonly bestEffort: string;
+    };
+    readonly examples: readonly InlineSelectorExample[];
+  };
   readonly posture: {
     readonly recommendation: 'local-default' | 'recommended-remote' | 'advanced-remote';
     readonly modeLabel: string;
@@ -115,9 +113,7 @@ export type ExposureContract = {
   };
 };
 
-export type AccessValidationResult =
-  | { readonly ok: true }
-  | ExposureValidationFailure;
+export type AccessValidationResult = { readonly ok: true } | ExposureValidationFailure;
 
 export function computePublishedPort(
   exposureMode: ExposureMode,
@@ -127,9 +123,7 @@ export function computePublishedPort(
   return exposureMode === 'private-network' ? basePort + routeIndex : basePort;
 }
 
-export function usesInlineSelectorAccess(
-  config: Pick<MullgateConfig, 'setup'>,
-): boolean {
+export function usesInlineSelectorAccess(config: Pick<MullgateConfig, 'setup'>): boolean {
   return config.setup.access.mode === 'inline-selector';
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -14,7 +14,14 @@ export const bindConfigSchema = z.object({
 
 export const authConfigSchema = z.object({
   username: nonEmptyString,
-  password: nonEmptyString,
+  password: z.string().trim(),
+});
+
+export const accessModeSchema = z.enum(['published-routes', 'inline-selector']);
+
+export const accessConfigSchema = z.object({
+  mode: accessModeSchema.default('published-routes'),
+  allowUnsafePublicEmptyPassword: z.boolean().default(false),
 });
 
 export const exposureModeSchema = z.enum(['loopback', 'private-network', 'public']);
@@ -169,6 +176,10 @@ export const guidedSetupSchema = z.object({
   source: z.literal('guided-setup'),
   bind: bindConfigSchema,
   auth: authConfigSchema,
+  access: accessConfigSchema.default({
+    mode: 'published-routes',
+    allowUnsafePublicEmptyPassword: false,
+  }),
   exposure: exposureConfigSchema,
   location: locationInputSchema,
   https: httpsConfigSchema,
@@ -197,6 +208,7 @@ export const mullgateConfigInputSchema = z.object({
 });
 
 export type ExposureMode = z.infer<typeof exposureModeSchema>;
+export type AccessMode = z.infer<typeof accessModeSchema>;
 export type ExposureConfig = z.infer<typeof exposureConfigSchema>;
 export type RoutedLocationExit = z.infer<typeof routedLocationExitSchema>;
 export type RoutedLocation = z.infer<typeof routedLocationSchema>;

--- a/src/runtime/render-runtime-bundle.ts
+++ b/src/runtime/render-runtime-bundle.ts
@@ -4,9 +4,11 @@ import path from 'node:path';
 import {
   buildExposureContract,
   computePublishedPort,
+  deriveInlineSelectorBindHost,
   deriveRuntimeBackendHost,
   deriveRuntimeListenerHost,
   type ExposureContract,
+  usesInlineSelectorAccess,
 } from '../config/exposure-contract.js';
 import type { MullgatePaths } from '../config/paths.js';
 import { REDACTED } from '../config/redact.js';
@@ -322,6 +324,10 @@ function buildPublishedEndpoints(
   config: MullgateConfig,
   https: Extract<ResolvedHttpsRuntime, { ok: true }>,
 ): RuntimeEndpoint[] {
+  if (usesInlineSelectorAccess(config)) {
+    return [];
+  }
+
   return config.routing.locations.flatMap((route, index) => {
     const endpoints: RuntimeEndpoint[] = [
       createEndpoint(config, route, index, 'socks5', config.setup.bind.socksPort),
@@ -372,24 +378,24 @@ function buildRuntimeBundleManifest(
   https: Extract<ResolvedHttpsRuntime, { ok: true }>,
   publishedEndpoints: readonly RuntimeEndpoint[],
 ): RuntimeBundleManifest {
+  const inlineSelectorEnabled = usesInlineSelectorAccess(config);
   const routeManifests = config.routing.locations.map((route, index) => {
     const routeEndpoints = publishedEndpoints.filter(
       (endpoint) => endpoint.routeId === route.runtime.routeId,
     );
-    const socks5Port = computePublishedPort(
-      config.setup.exposure.mode,
-      config.setup.bind.socksPort,
-      index,
-    );
-    const httpPort = computePublishedPort(
-      config.setup.exposure.mode,
-      config.setup.bind.httpPort,
-      index,
-    );
     const httpsPort = https.enabled
       ? computePublishedPort(config.setup.exposure.mode, https.port, index)
       : null;
-    const listenerHost = deriveRuntimeListenerHost(config.setup.exposure.mode, route.bindIp);
+    const bindHost = inlineSelectorEnabled ? deriveInlineSelectorBindHost(config) : route.bindIp;
+    const listenerHost = deriveRuntimeListenerHost(config.setup.exposure.mode, bindHost);
+    const socks5Port = inlineSelectorEnabled
+      ? config.setup.bind.socksPort
+      : computePublishedPort(config.setup.exposure.mode, config.setup.bind.socksPort, index);
+    const httpPort = inlineSelectorEnabled
+      ? config.setup.bind.httpPort
+      : computePublishedPort(config.setup.exposure.mode, config.setup.bind.httpPort, index);
+    const resolvedHttpsPort =
+      inlineSelectorEnabled && https.enabled ? https.port : httpsPort;
 
     return {
       routeId: route.runtime.routeId,
@@ -407,14 +413,15 @@ function buildRuntimeBundleManifest(
       listeners: {
         socks5: `${listenerHost}:${socks5Port}`,
         http: `${listenerHost}:${httpPort}`,
-        https: https.enabled && httpsPort !== null ? `${listenerHost}:${httpsPort}` : null,
+        https:
+          https.enabled && resolvedHttpsPort !== null ? `${listenerHost}:${resolvedHttpsPort}` : null,
       },
       services: {
         routeProxy: {
           name: ROUTE_PROXY_SERVICE,
         },
         backends: {
-          https: https.enabled ? route.runtime.httpsBackendName : null,
+          https: https.enabled && !inlineSelectorEnabled ? route.runtime.httpsBackendName : null,
         },
       },
       publishedEndpoints: routeEndpoints,
@@ -446,12 +453,14 @@ function buildRuntimeBundleManifest(
       routeProxy: {
         name: ROUTE_PROXY_SERVICE,
         listeners: {
-          socks5:
-            config.setup.exposure.mode === 'private-network'
+          socks5: inlineSelectorEnabled
+            ? `shared selector listener on ${CONTAINER_BIND_HOST}:${config.setup.bind.socksPort}`
+            : config.setup.exposure.mode === 'private-network'
               ? `shared host ${CONTAINER_BIND_HOST} with per-route ports starting at ${config.setup.bind.socksPort}`
               : `per-route bind IPs on port ${config.setup.bind.socksPort}`,
-          http:
-            config.setup.exposure.mode === 'private-network'
+          http: inlineSelectorEnabled
+            ? `shared selector listener on ${CONTAINER_BIND_HOST}:${config.setup.bind.httpPort}`
+            : config.setup.exposure.mode === 'private-network'
               ? `shared host ${CONTAINER_BIND_HOST} with per-route ports starting at ${config.setup.bind.httpPort}`
               : `per-route bind IPs on port ${config.setup.bind.httpPort}`,
         },
@@ -464,9 +473,11 @@ function buildRuntimeBundleManifest(
         name: ROUTING_LAYER_SERVICE,
         listeners: {
           https: https.enabled
-            ? config.setup.exposure.mode === 'private-network'
-              ? `shared host ${CONTAINER_BIND_HOST} with per-route ports starting at ${https.port}`
-              : `per-route bind IPs on port ${https.port}`
+            ? inlineSelectorEnabled
+              ? `shared selector listener on ${CONTAINER_BIND_HOST}:${https.port}`
+              : config.setup.exposure.mode === 'private-network'
+                ? `shared host ${CONTAINER_BIND_HOST} with per-route ports starting at ${https.port}`
+                : `per-route bind IPs on port ${https.port}`
             : null,
         },
         networkMode: HOST_NETWORK_MODE,
@@ -564,6 +575,7 @@ function buildHttpsSidecarConfig(
   config: MullgateConfig,
   https: Extract<ResolvedHttpsRuntime, { ok: true }>,
 ): string {
+  const inlineSelectorEnabled = usesInlineSelectorAccess(config);
   const lines = [
     '# Generated by Mullgate. Derived artifact; edit canonical config instead.',
     'global',
@@ -578,7 +590,17 @@ function buildHttpsSidecarConfig(
     '',
   ];
 
-  if (https.enabled && config.setup.exposure.mode === 'private-network') {
+  if (https.enabled && inlineSelectorEnabled) {
+    lines.push(
+      'frontend https_selector_proxy',
+      `  bind ${CONTAINER_BIND_HOST}:${https.port} ssl crt ${HAPROXY_COMBINED_PEM_PATH}`,
+      '  default_backend inline_selector_http_proxy',
+      '',
+      'backend inline_selector_http_proxy',
+      `  server inline-selector ${deriveRuntimeBackendHost(config.setup.exposure.mode, deriveInlineSelectorBindHost(config))}:${config.setup.bind.httpPort} check`,
+      '',
+    );
+  } else if (https.enabled && config.setup.exposure.mode === 'private-network') {
     for (const [index, route] of config.routing.locations.entries()) {
       const publishedPort = computePublishedPort(config.setup.exposure.mode, https.port, index);
       lines.push(
@@ -604,6 +626,10 @@ function buildHttpsSidecarConfig(
 
   for (const route of config.routing.locations) {
     if (https.enabled) {
+      if (inlineSelectorEnabled) {
+        continue;
+      }
+
       lines.push(
         `backend ${route.runtime.httpsBackendName}`,
         `  server ${route.runtime.routeId} ${deriveRuntimeBackendHost(config.setup.exposure.mode, route.bindIp)}:${resolveHttpBackendPort(config, route.runtime.routeId)} check`,

--- a/src/runtime/render-runtime-bundle.ts
+++ b/src/runtime/render-runtime-bundle.ts
@@ -394,8 +394,7 @@ function buildRuntimeBundleManifest(
     const httpPort = inlineSelectorEnabled
       ? config.setup.bind.httpPort
       : computePublishedPort(config.setup.exposure.mode, config.setup.bind.httpPort, index);
-    const resolvedHttpsPort =
-      inlineSelectorEnabled && https.enabled ? https.port : httpsPort;
+    const resolvedHttpsPort = inlineSelectorEnabled && https.enabled ? https.port : httpsPort;
 
     return {
       routeId: route.runtime.routeId,
@@ -414,7 +413,9 @@ function buildRuntimeBundleManifest(
         socks5: `${listenerHost}:${socks5Port}`,
         http: `${listenerHost}:${httpPort}`,
         https:
-          https.enabled && resolvedHttpsPort !== null ? `${listenerHost}:${resolvedHttpsPort}` : null,
+          https.enabled && resolvedHttpsPort !== null
+            ? `${listenerHost}:${resolvedHttpsPort}`
+            : null,
       },
       services: {
         routeProxy: {

--- a/src/runtime/render-runtime-proxies.ts
+++ b/src/runtime/render-runtime-proxies.ts
@@ -176,48 +176,48 @@ export function planRuntimeProxyArtifacts(
   const routes = inlineSelectorEnabled
     ? []
     : options.config.routing.locations.map((route, index) => {
-    const exit = route.mullvad.exit;
+        const exit = route.mullvad.exit;
 
-    if (!exit.relayHostname || !exit.relayFqdn || !exit.socksHostname || !exit.socksPort) {
-      return {
-        ok: false as const,
-        route,
-      };
-    }
+        if (!exit.relayHostname || !exit.relayFqdn || !exit.socksHostname || !exit.socksPort) {
+          return {
+            ok: false as const,
+            route,
+          };
+        }
 
-    return {
-      ok: true as const,
-      value: {
-        routeIndex: index,
-        routeId: route.runtime.routeId,
-        routeAlias: route.alias,
-        routeHostname: route.hostname,
-        routeBindIp: route.bindIp,
-        routeListenHost: deriveRuntimeListenerHost(
-          options.config.setup.exposure.mode,
-          route.bindIp,
-        ),
-        routeSocksPort: computePublishedPort(
-          options.config.setup.exposure.mode,
-          options.config.setup.bind.socksPort,
-          index,
-        ),
-        routeHttpPort: computePublishedPort(
-          options.config.setup.exposure.mode,
-          options.config.setup.bind.httpPort,
-          index,
-        ),
-        httpsBackendName: route.runtime.httpsBackendName,
-        exitRelayHostname: exit.relayHostname,
-        exitRelayFqdn: exit.relayFqdn,
-        exitSocksHostname: exit.socksHostname,
-        exitSocksPort: exit.socksPort,
-        entryParent: {
-          host: '127.0.0.1' as const,
-          port: ENTRY_WIREPROXY_SOCKS_PORT,
-        },
-      } satisfies RenderedRouteProxyRoute,
-    };
+        return {
+          ok: true as const,
+          value: {
+            routeIndex: index,
+            routeId: route.runtime.routeId,
+            routeAlias: route.alias,
+            routeHostname: route.hostname,
+            routeBindIp: route.bindIp,
+            routeListenHost: deriveRuntimeListenerHost(
+              options.config.setup.exposure.mode,
+              route.bindIp,
+            ),
+            routeSocksPort: computePublishedPort(
+              options.config.setup.exposure.mode,
+              options.config.setup.bind.socksPort,
+              index,
+            ),
+            routeHttpPort: computePublishedPort(
+              options.config.setup.exposure.mode,
+              options.config.setup.bind.httpPort,
+              index,
+            ),
+            httpsBackendName: route.runtime.httpsBackendName,
+            exitRelayHostname: exit.relayHostname,
+            exitRelayFqdn: exit.relayFqdn,
+            exitSocksHostname: exit.socksHostname,
+            exitSocksPort: exit.socksPort,
+            entryParent: {
+              host: '127.0.0.1' as const,
+              port: ENTRY_WIREPROXY_SOCKS_PORT,
+            },
+          } satisfies RenderedRouteProxyRoute,
+        };
       });
 
   const missingRoute = routes.find((route) => !route.ok);
@@ -390,7 +390,10 @@ function buildRouteProxyConfig(input: {
 
   if (input.config.setup.access.mode === 'inline-selector') {
     const sharedBindHost = deriveInlineSelectorBindHost(input.config);
-    const listenerHost = deriveRuntimeListenerHost(input.config.setup.exposure.mode, sharedBindHost);
+    const listenerHost = deriveRuntimeListenerHost(
+      input.config.setup.exposure.mode,
+      sharedBindHost,
+    );
     const users = input.inlineSelectors.map(
       (selector) => `${selector.selector}:CL:${input.config.setup.auth.password}`,
     );
@@ -432,7 +435,10 @@ function buildRouteProxyConfig(input: {
     return `${lines.join('\n')}\n`;
   }
 
-  lines.push(`users ${input.config.setup.auth.username}:CL:${input.config.setup.auth.password}`, '');
+  lines.push(
+    `users ${input.config.setup.auth.username}:CL:${input.config.setup.auth.password}`,
+    '',
+  );
 
   for (const route of input.routes) {
     // The shared entry hop must preserve the next-hop Mullvad SOCKS hostname through the tunnel.
@@ -480,7 +486,7 @@ function buildInlineSelectorMappings(input: {
 
       const relay =
         target.kind === 'relay'
-          ? constrainedRelays.find((candidate) => candidate.hostname === target.hostname) ?? null
+          ? (constrainedRelays.find((candidate) => candidate.hostname === target.hostname) ?? null)
           : choosePreferredRelay(
               constrainedRelays.filter((candidate) => relayMatchesTarget(candidate, target)),
             );

--- a/src/runtime/render-runtime-proxies.ts
+++ b/src/runtime/render-runtime-proxies.ts
@@ -1,6 +1,12 @@
 import { chmod, type FileHandle, mkdir, open, rename, rm } from 'node:fs/promises';
 import path from 'node:path';
-import { computePublishedPort, deriveRuntimeListenerHost } from '../config/exposure-contract.js';
+import {
+  computePublishedPort,
+  deriveInlineSelectorBindHost,
+  deriveRuntimeListenerHost,
+  usesInlineSelectorAccess,
+  validateAccessSettings,
+} from '../config/exposure-contract.js';
 import type { MullgatePaths } from '../config/paths.js';
 import type { MullgateConfig, RoutedLocation } from '../config/schema.js';
 import {
@@ -49,16 +55,26 @@ export type RenderedRuntimeProxyArtifacts = {
   readonly relayCachePath: string;
 };
 
+export type InlineSelectorMapping = {
+  readonly selector: string;
+  readonly target: LocationAliasTarget;
+  readonly exitRelayHostname: string;
+  readonly exitSocksHostname: string;
+  readonly exitSocksPort: number;
+};
+
 export type RenderRuntimeProxySuccess = {
   readonly ok: true;
   readonly phase: 'artifact-render';
   readonly source: 'canonical-config';
   readonly checkedAt: string;
+  readonly accessMode: MullgateConfig['setup']['access']['mode'];
   readonly entryRelay: MullvadRelay;
   readonly entryTarget: LocationAliasTarget | null;
   readonly entryWireproxyConfig: string;
   readonly routeProxyConfig: string;
   readonly routes: readonly RenderedRouteProxyRoute[];
+  readonly inlineSelectors: readonly InlineSelectorMapping[];
   readonly artifactPaths: RenderedRuntimeProxyArtifacts;
 };
 
@@ -71,6 +87,7 @@ export type RenderRuntimeProxyFailure = {
     | 'MISSING_WIREGUARD'
     | 'NO_MATCHING_ENTRY_RELAY'
     | 'MISSING_ROUTE_EXIT'
+    | 'INVALID_ACCESS_CONTRACT'
     | 'WRITE_FAILED';
   readonly message: string;
   readonly cause?: string;
@@ -95,6 +112,7 @@ export function planRuntimeProxyArtifacts(
   options: RenderRuntimeProxyOptions,
 ): RenderRuntimeProxyResult {
   const checkedAt = options.generatedAt ?? new Date().toISOString();
+  const inlineSelectorEnabled = usesInlineSelectorAccess(options.config);
 
   if (
     !options.config.mullvad.wireguard.publicKey ||
@@ -111,6 +129,28 @@ export function planRuntimeProxyArtifacts(
         'Cannot render runtime proxy artifacts before the shared Mullvad WireGuard device is fully provisioned.',
       artifactPath: options.paths.configFile,
       serviceName: ENTRY_TUNNEL_SERVICE,
+    };
+  }
+
+  const accessValidation = validateAccessSettings({
+    exposureMode: options.config.setup.exposure.mode,
+    accessMode: options.config.setup.access.mode,
+    password: options.config.setup.auth.password,
+    allowUnsafePublicEmptyPassword: options.config.setup.access.allowUnsafePublicEmptyPassword,
+    artifactPath: options.paths.configFile,
+  });
+
+  if (!accessValidation.ok) {
+    return {
+      ok: false,
+      phase: 'artifact-render',
+      source: 'user-input',
+      checkedAt,
+      code: 'INVALID_ACCESS_CONTRACT',
+      message: accessValidation.message,
+      ...(accessValidation.cause ? { cause: accessValidation.cause } : {}),
+      artifactPath: accessValidation.artifactPath,
+      serviceName: ROUTE_PROXY_SERVICE,
     };
   }
 
@@ -133,7 +173,9 @@ export function planRuntimeProxyArtifacts(
     };
   }
 
-  const routes = options.config.routing.locations.map((route, index) => {
+  const routes = inlineSelectorEnabled
+    ? []
+    : options.config.routing.locations.map((route, index) => {
     const exit = route.mullvad.exit;
 
     if (!exit.relayHostname || !exit.relayFqdn || !exit.socksHostname || !exit.socksPort) {
@@ -176,7 +218,7 @@ export function planRuntimeProxyArtifacts(
         },
       } satisfies RenderedRouteProxyRoute,
     };
-  });
+      });
 
   const missingRoute = routes.find((route) => !route.ok);
 
@@ -197,12 +239,33 @@ export function planRuntimeProxyArtifacts(
   const renderedRoutes = routes
     .filter((route): route is Extract<(typeof routes)[number], { ok: true }> => route.ok)
     .map((route) => route.value);
+  const inlineSelectors = inlineSelectorEnabled
+    ? buildInlineSelectorMappings({
+        config: options.config,
+        relayCatalog: options.relayCatalog,
+      })
+    : [];
+
+  if (inlineSelectorEnabled && inlineSelectors.length === 0) {
+    return {
+      ok: false,
+      phase: 'artifact-render',
+      source: 'relay-catalog',
+      checkedAt,
+      code: 'NO_MATCHING_ENTRY_RELAY',
+      message:
+        'No selectors could be resolved from the cached Mullvad relay catalog for inline-selector access.',
+      artifactPath: options.paths.provisioningCacheFile,
+      serviceName: ROUTE_PROXY_SERVICE,
+    };
+  }
 
   return {
     ok: true,
     phase: 'artifact-render',
     source: 'canonical-config',
     checkedAt,
+    accessMode: options.config.setup.access.mode,
     entryRelay: entryRelayResult.value.relay,
     entryTarget: entryRelayResult.value.target,
     entryWireproxyConfig: buildEntryWireproxyConfig({
@@ -213,9 +276,11 @@ export function planRuntimeProxyArtifacts(
     routeProxyConfig: buildRouteProxyConfig({
       config: options.config,
       routes: renderedRoutes,
+      inlineSelectors,
       generatedAt: checkedAt,
     }),
     routes: renderedRoutes,
+    inlineSelectors,
     artifactPaths: {
       entryWireproxyConfigPath: options.paths.entryWireproxyConfigFile,
       routeProxyConfigPath: options.paths.routeProxyConfigFile,
@@ -309,17 +374,65 @@ function buildEntryWireproxyConfig(input: {
 function buildRouteProxyConfig(input: {
   readonly config: MullgateConfig;
   readonly routes: readonly RenderedRouteProxyRoute[];
+  readonly inlineSelectors: readonly InlineSelectorMapping[];
   readonly generatedAt: string;
 }): string {
   const lines = [
     '# Generated by Mullgate. Derived artifact; edit canonical config instead.',
     `# Generated at ${input.generatedAt}`,
-    '# One shared 3proxy process publishes every per-route SOCKS5/HTTP listener.',
+    input.config.setup.access.mode === 'inline-selector'
+      ? '# One shared 3proxy process publishes selector-driven SOCKS5/HTTP listeners.'
+      : '# One shared 3proxy process publishes every per-route SOCKS5/HTTP listener.',
     'fakeresolve',
     'auth strong',
-    `users ${input.config.setup.auth.username}:CL:${input.config.setup.auth.password}`,
     '',
   ];
+
+  if (input.config.setup.access.mode === 'inline-selector') {
+    const sharedBindHost = deriveInlineSelectorBindHost(input.config);
+    const listenerHost = deriveRuntimeListenerHost(input.config.setup.exposure.mode, sharedBindHost);
+    const users = input.inlineSelectors.map(
+      (selector) => `${selector.selector}:CL:${input.config.setup.auth.password}`,
+    );
+
+    if (users.length > 0) {
+      lines.push(`users ${users.join(' ')}`, '');
+    }
+
+    for (const selector of input.inlineSelectors) {
+      lines.push(
+        `# Selector ${selector.selector} -> ${selector.exitRelayHostname}`,
+        `allow ${selector.selector}`,
+        `parent 1000 socks5+ 127.0.0.1 ${ENTRY_WIREPROXY_SOCKS_PORT}`,
+        `parent 1000 socks5+ ${selector.exitSocksHostname} ${selector.exitSocksPort}`,
+      );
+    }
+
+    lines.push(
+      `socks -p${input.config.setup.bind.socksPort} -i${listenerHost} -e${sharedBindHost}`,
+      'flush',
+      '',
+    );
+
+    for (const selector of input.inlineSelectors) {
+      lines.push(
+        `# HTTP selector ${selector.selector} -> ${selector.exitRelayHostname}`,
+        `allow ${selector.selector}`,
+        `parent 1000 socks5+ 127.0.0.1 ${ENTRY_WIREPROXY_SOCKS_PORT}`,
+        `parent 1000 socks5+ ${selector.exitSocksHostname} ${selector.exitSocksPort}`,
+      );
+    }
+
+    lines.push(
+      `proxy -p${input.config.setup.bind.httpPort} -i${listenerHost} -e${sharedBindHost}`,
+      'flush',
+      '',
+    );
+
+    return `${lines.join('\n')}\n`;
+  }
+
+  lines.push(`users ${input.config.setup.auth.username}:CL:${input.config.setup.auth.password}`, '');
 
   for (const route of input.routes) {
     // The shared entry hop must preserve the next-hop Mullvad SOCKS hostname through the tunnel.
@@ -340,6 +453,53 @@ function buildRouteProxyConfig(input: {
   }
 
   return `${lines.join('\n')}\n`;
+}
+
+function buildInlineSelectorMappings(input: {
+  readonly config: MullgateConfig;
+  readonly relayCatalog: MullvadRelayCatalog;
+}): InlineSelectorMapping[] {
+  const constrainedRelays = applyProviderConstraints(
+    input.relayCatalog.relays,
+    input.config.mullvad.relayConstraints.providers,
+  );
+  const catalogResult = createLocationAliasCatalog(constrainedRelays);
+
+  if (!catalogResult.ok) {
+    return [];
+  }
+
+  return Object.entries(catalogResult.value.index)
+    .filter(([, targets]) => targets.length === 1)
+    .flatMap(([selector, targets]) => {
+      const target = targets[0];
+
+      if (!target) {
+        return [];
+      }
+
+      const relay =
+        target.kind === 'relay'
+          ? constrainedRelays.find((candidate) => candidate.hostname === target.hostname) ?? null
+          : choosePreferredRelay(
+              constrainedRelays.filter((candidate) => relayMatchesTarget(candidate, target)),
+            );
+
+      if (!relay) {
+        return [];
+      }
+
+      return [
+        {
+          selector,
+          target,
+          exitRelayHostname: relay.hostname,
+          exitSocksHostname: `${relay.hostname}-socks.relays.mullvad.net`,
+          exitSocksPort: 1080,
+        } satisfies InlineSelectorMapping,
+      ];
+    })
+    .sort((left, right) => left.selector.localeCompare(right.selector));
 }
 
 function resolveEntryRelay(input: {

--- a/src/runtime/validate-runtime.ts
+++ b/src/runtime/validate-runtime.ts
@@ -4,9 +4,11 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { MullgateConfig } from '../config/schema.js';
+import { deriveRuntimeListenerHost } from '../config/exposure-contract.js';
 import { createDockerValidationStage } from './docker-validation-stage.js';
 import {
   ENTRY_WIREPROXY_SOCKS_PORT,
+  type InlineSelectorMapping,
   type RenderedRouteProxyRoute,
 } from './render-runtime-proxies.js';
 import { validateWireproxyConfig, type WireproxyValidationIssue } from './validate-wireproxy.js';
@@ -60,6 +62,10 @@ export type ValidateRuntimeOptions = {
   readonly routeProxyConfigPath: string;
   readonly routeProxyConfigText?: string;
   readonly routes: readonly RenderedRouteProxyRoute[];
+  readonly inlineSelectors?: readonly InlineSelectorMapping[];
+  readonly accessMode: MullgateConfig['setup']['access']['mode'];
+  readonly exposureMode: MullgateConfig['setup']['exposure']['mode'];
+  readonly bindHost: string;
   readonly bind: Pick<MullgateConfig['setup']['bind'], 'socksPort' | 'httpPort'>;
   readonly checkedAt?: string;
   readonly reportPath?: string;
@@ -91,6 +97,10 @@ export async function validateRuntimeArtifacts(
     configPath: options.routeProxyConfigPath,
     configText: options.routeProxyConfigText,
     routes: options.routes,
+    inlineSelectors: options.inlineSelectors ?? [],
+    accessMode: options.accessMode,
+    exposureMode: options.exposureMode,
+    bindHost: options.bindHost,
     bind: options.bind,
     checkedAt,
     dockerBinary: options.dockerBinary,
@@ -149,6 +159,10 @@ function validateRouteProxyConfig(input: {
   readonly configPath: string;
   readonly configText?: string;
   readonly routes: readonly RenderedRouteProxyRoute[];
+  readonly inlineSelectors: readonly InlineSelectorMapping[];
+  readonly accessMode: MullgateConfig['setup']['access']['mode'];
+  readonly exposureMode: MullgateConfig['setup']['exposure']['mode'];
+  readonly bindHost: string;
   readonly bind: Pick<MullgateConfig['setup']['bind'], 'socksPort' | 'httpPort'>;
   readonly checkedAt: string;
   readonly dockerBinary?: string;
@@ -173,6 +187,10 @@ function validateRouteProxyConfig(input: {
     configText,
     configPath: input.configPath,
     routes: input.routes,
+    inlineSelectors: input.inlineSelectors,
+    accessMode: input.accessMode,
+    exposureMode: input.exposureMode,
+    bindHost: input.bindHost,
     bind: input.bind,
   });
 
@@ -307,6 +325,10 @@ function validateRouteProxySyntax(input: {
   readonly configText: string;
   readonly configPath: string;
   readonly routes: readonly RenderedRouteProxyRoute[];
+  readonly inlineSelectors: readonly InlineSelectorMapping[];
+  readonly accessMode: MullgateConfig['setup']['access']['mode'];
+  readonly exposureMode: MullgateConfig['setup']['exposure']['mode'];
+  readonly bindHost: string;
   readonly bind: Pick<MullgateConfig['setup']['bind'], 'socksPort' | 'httpPort'>;
 }): RuntimeValidationIssue[] {
   const issues: RuntimeValidationIssue[] = [];
@@ -335,6 +357,44 @@ function validateRouteProxySyntax(input: {
       target: input.configPath,
       message: 'Route proxy config must define one authenticated user.',
     });
+  }
+
+  if (input.accessMode === 'inline-selector') {
+    const listenerHost = deriveRuntimeListenerHost(input.exposureMode, input.bindHost);
+    const expectedSocks = `socks -p${input.bind.socksPort} -i${listenerHost} -e${input.bindHost}`;
+    const expectedHttp = `proxy -p${input.bind.httpPort} -i${listenerHost} -e${input.bindHost}`;
+
+    if (!lines.includes(expectedSocks)) {
+      issues.push({
+        target: input.configPath,
+        message: 'Inline-selector config is missing its shared SOCKS5 listener line.',
+      });
+    }
+
+    if (!lines.includes(expectedHttp)) {
+      issues.push({
+        target: input.configPath,
+        message: 'Inline-selector config is missing its shared HTTP listener line.',
+      });
+    }
+
+    for (const selector of input.inlineSelectors) {
+      if (!lines.includes(`allow ${selector.selector}`)) {
+        issues.push({
+          target: input.configPath,
+          message: `Inline-selector config is missing ACLs for selector ${selector.selector}.`,
+        });
+      }
+
+      if (!lines.includes(`parent 1000 socks5+ ${selector.exitSocksHostname} ${selector.exitSocksPort}`)) {
+        issues.push({
+          target: input.configPath,
+          message: `Inline-selector config is missing an upstream parent for selector ${selector.selector}.`,
+        });
+      }
+    }
+
+    return issues;
   }
 
   for (const route of input.routes) {

--- a/src/runtime/validate-runtime.ts
+++ b/src/runtime/validate-runtime.ts
@@ -3,8 +3,8 @@ import { readFileSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import type { MullgateConfig } from '../config/schema.js';
 import { deriveRuntimeListenerHost } from '../config/exposure-contract.js';
+import type { MullgateConfig } from '../config/schema.js';
 import { createDockerValidationStage } from './docker-validation-stage.js';
 import {
   ENTRY_WIREPROXY_SOCKS_PORT,
@@ -386,7 +386,11 @@ function validateRouteProxySyntax(input: {
         });
       }
 
-      if (!lines.includes(`parent 1000 socks5+ ${selector.exitSocksHostname} ${selector.exitSocksPort}`)) {
+      if (
+        !lines.includes(
+          `parent 1000 socks5+ ${selector.exitSocksHostname} ${selector.exitSocksPort}`,
+        )
+      ) {
         issues.push({
           target: input.configPath,
           message: `Inline-selector config is missing an upstream parent for selector ${selector.selector}.`,

--- a/test/cli/config-command.test.ts
+++ b/test/cli/config-command.test.ts
@@ -56,6 +56,10 @@ function createFixtureConfig(): MullgateConfig {
         username: 'alice',
         password: 'multi-route-secret',
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: 'loopback',
         allowLan: false,
@@ -470,6 +474,34 @@ copy/paste hosts block
     `);
   });
 
+  it('renders selector-driven access guidance when inline-selector mode is enabled', () => {
+    const config = createFixtureConfig();
+    config.setup.access.mode = 'inline-selector';
+    config.setup.auth.password = '';
+    config.setup.exposure = {
+      mode: 'private-network',
+      allowLan: true,
+      baseDomain: null,
+    };
+    config.setup.bind.host = '100.124.44.113';
+    config.runtime.status = {
+      phase: 'unvalidated',
+      lastCheckedAt: null,
+      message:
+        'Exposure settings changed; rerun `mullgate validate` or `mullgate start` to refresh runtime artifacts.',
+    };
+
+    const report = renderExposureReport(config, '/tmp/mullgate-home/config/mullgate/config.json');
+
+    expect(report).toContain('access mode: inline-selector');
+    expect(report).toContain('shared host: 100.124.44.113');
+    expect(report).toContain('selector field: username');
+    expect(report).toContain('guaranteed syntax: selector:@host:port');
+    expect(report).toContain('best-effort syntax: selector@host:port');
+    expect(report).toContain('guaranteed: socks5://se:[redacted]@100.124.44.113:1080');
+    expect(report).toContain('best effort: socks5://se@100.124.44.113:1080');
+  });
+
   it('updates exposure settings without raw JSON edits and mirrors the first bind IP back to setup.bind.host', () => {
     const config = createFixtureConfig();
 
@@ -510,6 +542,63 @@ copy/paste hosts block
     expect(
       `\n${renderExposureReport(result.config, '/tmp/mullgate-home/config/mullgate/config.json')}`,
     ).toContain('dns: sweden-gothenburg.proxy.example.com A 192.168.10.10');
+  });
+
+  it('rejects public inline-selector exposure with an empty password unless the unsafe override is enabled', () => {
+    const config = createFixtureConfig();
+    config.setup.auth.password = '';
+
+    const result = updateExposureConfig(config, '/tmp/mullgate-home/config/mullgate/config.json', {
+      mode: 'public',
+      accessMode: 'inline-selector',
+      baseDomainSpecified: false,
+      routeBindIps: ['203.0.113.10'],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      phase: 'setup-validation',
+      source: 'input',
+      code: 'UNSAFE_PUBLIC_INLINE_SELECTOR_EMPTY_PASSWORD',
+      message:
+        'Public inline-selector access with an empty password is blocked unless the unsafe override is enabled.',
+      cause:
+        'Set setup.access.allowUnsafePublicEmptyPassword=true or choose a non-empty proxy password before exposing selector-driven listeners on a public host.',
+      artifactPath: '/tmp/mullgate-home/config/mullgate/config.json',
+    });
+  });
+
+  it('allows public inline-selector exposure with an empty password when the unsafe override is enabled', () => {
+    const config = createFixtureConfig();
+    config.setup.auth.password = '';
+
+    const result = updateExposureConfig(config, '/tmp/mullgate-home/config/mullgate/config.json', {
+      mode: 'public',
+      accessMode: 'inline-selector',
+      allowUnsafePublicEmptyPassword: true,
+      baseDomainSpecified: false,
+      routeBindIps: ['203.0.113.10'],
+    });
+
+    expect(result.ok).toBe(true);
+
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.config.setup.access).toEqual({
+      mode: 'inline-selector',
+      allowUnsafePublicEmptyPassword: true,
+    });
+    expect(result.config.setup.bind.host).toBe('203.0.113.10');
+    expect(new Set(result.config.routing.locations.map((location) => location.bindIp))).toEqual(
+      new Set(['203.0.113.10']),
+    );
+    expect(
+      renderExposureReport(result.config, '/tmp/mullgate-home/config/mullgate/config.json'),
+    ).toContain(
+      'warning: Inline-selector access is exposing a public listener with an empty password. This is only appropriate when you intentionally accept selector-only proxy access on the public host.',
+    );
   });
 
   it('rejects ambiguous non-loopback bind IP edits with an explicit routed-exposure failure', () => {
@@ -853,6 +942,28 @@ copy/paste hosts block
     }
 
     expect(result.entries.map((entry) => entry.alias)).toEqual(['sweden-gothenburg']);
+  });
+
+  it('fails proxy export explicitly when inline-selector mode is enabled', () => {
+    const config = createFixtureConfig();
+    config.setup.access.mode = 'inline-selector';
+
+    const result = buildProxyExportPlan({
+      config,
+      protocol: 'socks5',
+      selectors: [],
+      relayCatalog: createFixtureRelayCatalog(),
+      configPath: '/tmp/mullgate-home/config/mullgate/config.json',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      phase: 'export-proxies',
+      source: 'canonical-config',
+      message:
+        'Proxy export currently supports published-routes mode only. Inline-selector access uses one shared listener, so switch back to published-routes or use `mullgate proxy access` for selector examples.',
+      configPath: '/tmp/mullgate-home/config/mullgate/config.json',
+    });
   });
 
   it('renders the curated region group report', () => {

--- a/test/cli/doctor-command.test.ts
+++ b/test/cli/doctor-command.test.ts
@@ -85,6 +85,10 @@ function createFixtureConfig(env: NodeJS.ProcessEnv): MullgateConfig {
         username: 'alice',
         password: 'proxy-password',
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: 'loopback',
         allowLan: false,
@@ -536,6 +540,7 @@ describe('mullgate doctor command', () => {
       5. exposure-contract: pass
          summary: Saved exposure contract is internally coherent.
          detail: mode=loopback
+         detail: access-mode=published-routes
          detail: mode-label=Loopback / local-only
          detail: recommendation=local-default
          detail: posture-summary=Recommended default for same-machine use. Remote clients are intentionally out of scope in this posture.
@@ -740,6 +745,7 @@ describe('mullgate doctor command', () => {
       5. exposure-contract: pass
          summary: Saved exposure contract is internally coherent.
          detail: mode=loopback
+         detail: access-mode=published-routes
          detail: mode-label=Loopback / local-only
          detail: recommendation=local-default
          detail: posture-summary=Recommended default for same-machine use. Remote clients are intentionally out of scope in this posture.
@@ -941,6 +947,7 @@ describe('mullgate doctor command', () => {
       5. exposure-contract: degraded
          summary: Saved exposure contract includes warning-level posture guidance that operators should resolve or consciously accept.
          detail: mode=loopback
+         detail: access-mode=published-routes
          detail: mode-label=Loopback / local-only
          detail: recommendation=local-default
          detail: posture-summary=Recommended default for same-machine use. Remote clients are intentionally out of scope in this posture.
@@ -1128,6 +1135,7 @@ describe('mullgate doctor command', () => {
       5. exposure-contract: pass
          summary: Saved exposure contract is internally coherent.
          detail: mode=loopback
+         detail: access-mode=published-routes
          detail: mode-label=Loopback / local-only
          detail: recommendation=local-default
          detail: posture-summary=Recommended default for same-machine use. Remote clients are intentionally out of scope in this posture.
@@ -1291,6 +1299,7 @@ describe('mullgate doctor command', () => {
       5. exposure-contract: pass
          summary: Saved exposure contract is internally coherent.
          detail: mode=private-network
+         detail: access-mode=published-routes
          detail: mode-label=Private network / Tailscale-first
          detail: recommendation=recommended-remote
          detail: posture-summary=Recommended remote posture. Use this for Tailscale, LAN, or other trusted private overlays before considering public exposure.
@@ -1488,6 +1497,7 @@ describe('mullgate doctor command', () => {
       5. exposure-contract: pass
          summary: Saved exposure contract is internally coherent.
          detail: mode=loopback
+         detail: access-mode=published-routes
          detail: mode-label=Loopback / local-only
          detail: recommendation=local-default
          detail: posture-summary=Recommended default for same-machine use. Remote clients are intentionally out of scope in this posture.

--- a/test/cli/help-command.test.ts
+++ b/test/cli/help-command.test.ts
@@ -237,15 +237,19 @@ describe('mullgate help command contract', () => {
       and DNS guidance.
 
       Options:
-        --mode <mode>           Set exposure mode to loopback, private-network, or
-                                public.
-        --base-domain <domain>  Set the base domain used to derive per-route
-                                hostnames.
-        --clear-base-domain     Remove any configured base domain and fall back to
-                                alias/direct-IP hostnames.
-        --route-bind-ip <ip>    Set an ordered per-route bind IP. Repeat once per
-                                route. (default: [])
-        -h, --help              display help for command"
+        --mode <mode>                   Set exposure mode to loopback,
+                                        private-network, or public.
+        --access-mode <mode>            Set access mode to published-routes or
+                                        inline-selector.
+        --base-domain <domain>          Set the base domain used to derive per-route
+                                        hostnames.
+        --unsafe-public-empty-password  Allow empty passwords when inline-selector is
+                                        exposed on a public host.
+        --clear-base-domain             Remove any configured base domain and fall
+                                        back to alias/direct-IP hostnames.
+        --route-bind-ip <ip>            Set an ordered per-route bind IP. Repeat once
+                                        per route. (default: [])
+        -h, --help                      display help for command"
     `);
     expect(`\n${proxyExportHelp}`).toMatchInlineSnapshot(`
       "

--- a/test/cli/relays-and-recommend-command.test.ts
+++ b/test/cli/relays-and-recommend-command.test.ts
@@ -62,6 +62,10 @@ function createFixtureConfig(store: ConfigStore): MullgateConfig {
         username: 'alice',
         password: 'multi-route-secret',
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: 'private-network',
         allowLan: true,

--- a/test/cli/start-command.test.ts
+++ b/test/cli/start-command.test.ts
@@ -73,6 +73,10 @@ function createFixtureConfig(env: NodeJS.ProcessEnv): MullgateConfig {
         username: 'alice',
         password: 'proxy-password',
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: 'loopback',
         allowLan: false,
@@ -334,6 +338,7 @@ describe('mullgate start command', () => {
       source: docker-compose
       attempted at: 2026-03-21T01:00:00.000Z
       routes: 2
+      access mode: published-routes
       config: /tmp/mullgate-home/config/mullgate/config.json
       entry wireproxy config: /tmp/mullgate-home/state/mullgate/runtime/entry-wireproxy.conf
       route proxy config: /tmp/mullgate-home/state/mullgate/runtime/route-proxy.cfg
@@ -461,6 +466,7 @@ describe('mullgate start command', () => {
       source: docker-compose
       attempted at: 2026-03-21T01:02:00.000Z
       routes: 1
+      access mode: published-routes
       config: /tmp/mullgate-home/config/mullgate/config.json
       entry wireproxy config: /tmp/mullgate-home/state/mullgate/runtime/entry-wireproxy.conf
       route proxy config: /tmp/mullgate-home/state/mullgate/runtime/route-proxy.cfg

--- a/test/cli/status-command.test.ts
+++ b/test/cli/status-command.test.ts
@@ -72,6 +72,10 @@ function createFixtureConfig(env: NodeJS.ProcessEnv): MullgateConfig {
         username: 'alice',
         password: 'proxy-password',
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: 'loopback',
         allowLan: false,

--- a/test/config-store.test.ts
+++ b/test/config-store.test.ts
@@ -109,6 +109,10 @@ function createFixtureConfig(env: NodeJS.ProcessEnv): MullgateConfig {
         username: 'alice',
         password: 'super-secret-password',
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: 'loopback',
         allowLan: false,

--- a/test/mullvad-provisioning.test.ts
+++ b/test/mullvad-provisioning.test.ts
@@ -146,6 +146,10 @@ function createConfig(
         username: 'alice',
         password: 'super-secret-password',
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: 'loopback',
         allowLan: false,
@@ -643,6 +647,10 @@ describe('Mullvad provisioning and runtime artifact rendering', () => {
       routeProxyConfigPath: renderResult.artifactPaths.routeProxyConfigPath,
       routeProxyConfigText: renderResult.routeProxyConfig,
       routes: renderResult.routes,
+      inlineSelectors: renderResult.inlineSelectors,
+      accessMode: config.setup.access.mode,
+      exposureMode: config.setup.exposure.mode,
+      bindHost: config.setup.bind.host,
       bind: {
         socksPort: config.setup.bind.socksPort,
         httpPort: config.setup.bind.httpPort,
@@ -765,6 +773,10 @@ describe('Mullvad provisioning and runtime artifact rendering', () => {
         routeProxyConfigPath: renderResult.artifactPaths.routeProxyConfigPath,
         routeProxyConfigText: renderResult.routeProxyConfig,
         routes: renderResult.routes,
+        inlineSelectors: renderResult.inlineSelectors,
+        accessMode: config.setup.access.mode,
+        exposureMode: config.setup.exposure.mode,
+        bindHost: config.setup.bind.host,
         bind: {
           socksPort: config.setup.bind.socksPort,
           httpPort: config.setup.bind.httpPort,

--- a/test/runtime/render-runtime-bundle.test.ts
+++ b/test/runtime/render-runtime-bundle.test.ts
@@ -598,9 +598,7 @@ describe('renderRuntimeBundle', () => {
     );
     expect(result.httpsSidecarConfig).toContain('frontend https_selector_proxy');
     expect(result.httpsSidecarConfig).toContain('default_backend inline_selector_http_proxy');
-    expect(result.httpsSidecarConfig).toContain(
-      'server inline-selector 127.0.0.1:8080 check',
-    );
+    expect(result.httpsSidecarConfig).toContain('server inline-selector 127.0.0.1:8080 check');
     expect(result.httpsSidecarConfig).not.toContain('backend route-se-got-wg-101');
   });
 

--- a/test/runtime/render-runtime-bundle.test.ts
+++ b/test/runtime/render-runtime-bundle.test.ts
@@ -95,6 +95,10 @@ function createFixtureConfig(env: NodeJS.ProcessEnv): MullgateConfig {
         username: 'alice',
         password: 'super-secret-password',
       },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
       exposure: {
         mode: 'loopback',
         allowLan: false,
@@ -561,6 +565,43 @@ describe('renderRuntimeBundle', () => {
       'SINGLE_ROUTE',
       'RUNTIME_UNVALIDATED',
     ]);
+  });
+
+  it('renders one shared HTTPS frontend when inline-selector mode is enabled', () => {
+    const env = createTempEnvironment();
+    const paths = resolveMullgatePaths(env);
+    const config = createFixtureConfig(env);
+    config.setup.access.mode = 'inline-selector';
+    config.setup.exposure = {
+      mode: 'private-network',
+      allowLan: true,
+      baseDomain: null,
+    };
+    config.setup.bind.host = '100.124.44.113';
+
+    const result = planRuntimeBundle({
+      config,
+      paths,
+      generatedAt: '2026-03-20T19:00:00.000Z',
+    });
+
+    expect(result.ok).toBe(true);
+
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.manifest.exposure.accessMode).toBe('inline-selector');
+    expect(result.manifest.publishedEndpoints).toEqual([]);
+    expect(result.manifest.routes.every((route) => route.publishedEndpoints.length === 0)).toBe(
+      true,
+    );
+    expect(result.httpsSidecarConfig).toContain('frontend https_selector_proxy');
+    expect(result.httpsSidecarConfig).toContain('default_backend inline_selector_http_proxy');
+    expect(result.httpsSidecarConfig).toContain(
+      'server inline-selector 127.0.0.1:8080 check',
+    );
+    expect(result.httpsSidecarConfig).not.toContain('backend route-se-got-wg-101');
   });
 
   it('fails when HTTPS is requested without both TLS asset paths', async () => {


### PR DESCRIPTION
**Summary**
- add `inline-selector` access mode with one shared listener per protocol and selector-driven routing
- make `private-network` Tailscale-first so trusted-network exposure uses one shared host IP
- fix Linux autostart so proxies come back after reboot
- update README, operator docs, docs-site pages, and `SKILL.md` to match the shipped CLI behavior

**Verification**
- `rtk tsc`
- `rtk vitest run test/cli/help-command.test.ts test/cli/config-command.test.ts`

**Docs and release notes**
- `CHANGELOG.md` updated under `Unreleased`
- docs updated for Tailscale/private-network, `inline-selector`, `published-routes` export limits, and public empty-password safety

**Risks**
- release still needs the version bump, `CHANGELOG` section cut, `make release-check`, `npm pack --dry-run`, and the tag/publish flow on `main`