### PR TITLE
fix(deps): bump fumadocs-core/ui and eslint-config-next to patch CVEs

### DIFF
--- a/docs/mullgate-docs/package.json
+++ b/docs/mullgate-docs/package.json
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@takumi-rs/image-response": "^0.73.1",
-    "fumadocs-core": "16.7.4",
+    "fumadocs-core": "16.7.9",
     "fumadocs-mdx": "14.2.11",
-    "fumadocs-ui": "16.7.4",
+    "fumadocs-ui": "16.7.9",
     "lucide-react": "^0.577.0",
     "next": "16.2.1",
     "next-themes": "^0.4.6",
@@ -29,7 +29,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "eslint": "^10.1.0",
-    "eslint-config-next": "16.2.1",
+    "eslint-config-next": "16.2.2",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.2",
     "typescript": "^5.9.3"


### PR DESCRIPTION
Bumps in docs/mullgate-docs/package.json:

- fumadocs-core: 16.7.4 → 16.7.9 (fixes path-to-regexp ReDoS CVE)
- fumadocs-ui: 16.7.4 → 16.7.9
- eslint-config-next: 16.2.1 → 16.2.2 (fixes picomatch ReDoS CVE)

All 118 tests pass. Addresses P0 findings from #16.