### PR TITLE
fix(security): harden redaction sync, temp file naming, public exposure warning

### DIFF
--- a/src/config/exposure-contract.ts
+++ b/src/config/exposure-contract.ts
@@ -157,6 +157,16 @@ export function validateAccessSettings(input: {
     };
   }
 
+  if (
+    input.allowUnsafePublicEmptyPassword &&
+    input.exposureMode === 'public' &&
+    input.password.length === 0
+  ) {
+    console.warn(
+      'SECURITY WARNING: Public exposure is enabled with an empty proxy password because `setup.access.allowUnsafePublicEmptyPassword=true`. This publishes an internet-reachable listener without a password gate. Proceed only if this is deliberate and you accept the risk.',
+    );
+  }
+
   return { ok: true };
 }
 

--- a/src/config/redact.ts
+++ b/src/config/redact.ts
@@ -1,4 +1,8 @@
-import type { MullgateConfig } from './schema.js';
+import {
+  type MullgateConfig,
+  type SensitiveConfigFieldPath,
+  sensitiveConfigFieldPaths,
+} from './schema.js';
 
 export const REDACTED = '[redacted]';
 
@@ -59,12 +63,31 @@ function redactOptionalText(value: string | null, config: MullgateConfig): strin
   return value ? redactSensitiveText(value, config) : value;
 }
 
-function collectKnownSecrets(config: MullgateConfig): string[] {
-  return [
-    config.mullvad.accountNumber,
-    config.setup.auth.password,
-    config.mullvad.wireguard.privateKey,
-  ].filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
+/**
+ * Sensitive fields from `src/config/schema.ts`. This list MUST be kept in sync
+ * whenever the config schema changes:
+ * - `setup.auth.password`
+ * - `mullvad.accountNumber`
+ * - `mullvad.wireguard.privateKey`
+ */
+export function collectKnownSecrets(config: MullgateConfig): string[] {
+  return sensitiveConfigFieldPaths
+    .map((path) => readSensitiveConfigField(config, path))
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
+}
+
+function readSensitiveConfigField(
+  config: MullgateConfig,
+  path: SensitiveConfigFieldPath,
+): string | null {
+  switch (path) {
+    case 'setup.auth.password':
+      return config.setup.auth.password;
+    case 'mullvad.accountNumber':
+      return config.mullvad.accountNumber;
+    case 'mullvad.wireguard.privateKey':
+      return config.mullvad.wireguard.privateKey;
+  }
 }
 
 function redactProvisioning(provisioning: MullgateConfig['mullvad']): MullgateConfig['mullvad'] {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -196,6 +196,14 @@ export const mullgateConfigSchema = z.object({
   diagnostics: diagnosticsSchema,
 });
 
+export const sensitiveConfigFieldPaths = [
+  'setup.auth.password',
+  'mullvad.accountNumber',
+  'mullvad.wireguard.privateKey',
+] as const;
+
+export type SensitiveConfigFieldPath = (typeof sensitiveConfigFieldPaths)[number];
+
 export const mullgateConfigInputSchema = z.object({
   version: z.literal(CONFIG_VERSION),
   createdAt: timestampString,

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import {
   chmod,
   type FileHandle,
@@ -420,9 +421,10 @@ async function ensureDirectory(directoryPath: string): Promise<void> {
 
 async function writeFileAtomic(filePath: string, content: string, mode: number): Promise<void> {
   const directory = path.dirname(filePath);
+  const randomSuffix = crypto.randomBytes(4).readUInt32LE(0);
   const temporaryPath = path.join(
     directory,
-    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.tmp`,
+    `.${path.basename(filePath)}.${process.pid}.${randomSuffix}.tmp`,
   );
 
   let fileHandle: FileHandle | undefined;

--- a/test/config/redact.test.ts
+++ b/test/config/redact.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveMullgatePaths } from '../../src/config/paths.js';
+import { collectKnownSecrets } from '../../src/config/redact.js';
+import {
+  CONFIG_VERSION,
+  mullgateConfigSchema,
+  sensitiveConfigFieldPaths,
+  type MullgateConfig,
+} from '../../src/config/schema.js';
+import { createFixtureRoute, createFixtureRuntime } from '../helpers/mullgate-fixtures.js';
+
+function createFixtureConfig(): MullgateConfig {
+  const paths = resolveMullgatePaths({
+    ...process.env,
+    MULLGATE_PLATFORM: 'linux',
+    XDG_CONFIG_HOME: '/tmp/mullgate/config',
+    XDG_STATE_HOME: '/tmp/mullgate/state',
+    XDG_CACHE_HOME: '/tmp/mullgate/cache',
+  });
+
+  return mullgateConfigSchema.parse({
+    version: CONFIG_VERSION,
+    createdAt: '2026-03-20T18:48:01.000Z',
+    updatedAt: '2026-03-20T18:48:01.000Z',
+    setup: {
+      source: 'guided-setup',
+      bind: {
+        host: '127.0.0.1',
+        socksPort: 1080,
+        httpPort: 8080,
+        httpsPort: 8443,
+      },
+      auth: {
+        username: 'alice',
+        password: 'password-secret',
+      },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
+      exposure: {
+        mode: 'loopback',
+        allowLan: false,
+        baseDomain: null,
+      },
+      location: {
+        requested: 'se-sto',
+        country: 'Sweden',
+        city: 'Stockholm',
+        hostnameLabel: 'se-sto',
+        resolvedAlias: null,
+      },
+      https: {
+        enabled: false,
+      },
+    },
+    mullvad: {
+      accountNumber: '123456789012',
+      deviceName: 'mullgate-test-host',
+      lastProvisionedAt: null,
+      relayConstraints: {
+        ownership: 'mullvad-owned',
+        providers: ['31173'],
+      },
+      wireguard: {
+        publicKey: 'public-key-value',
+        privateKey: 'private-key-secret',
+        ipv4Address: null,
+        ipv6Address: null,
+        gatewayIpv4: null,
+        gatewayIpv6: null,
+        dnsServers: ['10.64.0.1'],
+        peerPublicKey: null,
+        peerEndpoint: null,
+      },
+    },
+    routing: {
+      locations: [
+        createFixtureRoute({
+          alias: 'se-sto',
+          hostname: 'se-sto',
+          bindIp: '127.0.0.1',
+          requested: 'se-sto',
+          country: 'Sweden',
+          city: 'Stockholm',
+          hostnameLabel: 'se-sto',
+          resolvedAlias: null,
+          providers: ['31173'],
+          exit: {
+            countryCode: 'se',
+            cityCode: 'sto',
+          },
+        }),
+      ],
+    },
+    runtime: createFixtureRuntime({
+      paths,
+      status: {
+        phase: 'unvalidated',
+        lastCheckedAt: null,
+        message: 'Pending first render.',
+      },
+    }),
+    diagnostics: {
+      lastRuntimeStartReportPath: paths.runtimeStartDiagnosticsFile,
+      lastRuntimeStart: null,
+    },
+  });
+}
+
+describe('config redaction secret coverage', () => {
+  it('keeps collectKnownSecrets in sync with every schema-owned sensitive field', () => {
+    const config = createFixtureConfig();
+    const collectedSecrets = new Set(collectKnownSecrets(config));
+
+    const expectedSecrets = new Map(
+      sensitiveConfigFieldPaths.map((path) => {
+        switch (path) {
+          case 'setup.auth.password':
+            return [path, config.setup.auth.password];
+          case 'mullvad.accountNumber':
+            return [path, config.mullvad.accountNumber];
+          case 'mullvad.wireguard.privateKey':
+            return [path, config.mullvad.wireguard.privateKey];
+        }
+      }),
+    );
+
+    expect(expectedSecrets.size).toBe(sensitiveConfigFieldPaths.length);
+
+    for (const [path, secret] of expectedSecrets) {
+      expect(secret, `${path} should stay non-empty in the fixture`).toBeTruthy();
+      expect(collectedSecrets.has(secret as string), `${path} is missing from collectKnownSecrets()`).toBe(
+        true,
+      );
+    }
+  });
+});

--- a/test/redact.test.ts
+++ b/test/redact.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveMullgatePaths } from '../src/config/paths.js';
+import { collectKnownSecrets } from '../src/config/redact.js';
+import {
+  CONFIG_VERSION,
+  mullgateConfigSchema,
+  type MullgateConfig,
+  sensitiveConfigFieldPaths,
+} from '../src/config/schema.js';
+import { createFixtureRoute, createFixtureRuntime } from './helpers/mullgate-fixtures.js';
+
+describe('collectKnownSecrets', () => {
+  it('includes every sensitive schema field value', () => {
+    const config = createFixtureConfig();
+    const secrets = collectKnownSecrets(config);
+
+    expect(sensitiveConfigFieldPaths).toEqual([
+      'setup.auth.password',
+      'mullvad.accountNumber',
+      'mullvad.wireguard.privateKey',
+    ]);
+
+    for (const path of sensitiveConfigFieldPaths) {
+      expect(secrets).toContain(readConfigValue(config, path));
+    }
+  });
+});
+
+function readConfigValue(
+  config: MullgateConfig,
+  path: (typeof sensitiveConfigFieldPaths)[number],
+): string {
+  switch (path) {
+    case 'setup.auth.password':
+      return config.setup.auth.password;
+    case 'mullvad.accountNumber':
+      return config.mullvad.accountNumber;
+    case 'mullvad.wireguard.privateKey':
+      return config.mullvad.wireguard.privateKey ?? '';
+  }
+}
+
+function createFixtureConfig(): MullgateConfig {
+  const paths = resolveMullgatePaths({
+    ...process.env,
+    MULLGATE_PLATFORM: 'linux',
+    XDG_CONFIG_HOME: '/tmp/mullgate-redact-schema-sync/config',
+    XDG_STATE_HOME: '/tmp/mullgate-redact-schema-sync/state',
+    XDG_CACHE_HOME: '/tmp/mullgate-redact-schema-sync/cache',
+  });
+  const timestamp = '2026-03-20T18:48:01.000Z';
+
+  return mullgateConfigSchema.parse({
+    version: CONFIG_VERSION,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    setup: {
+      source: 'guided-setup',
+      bind: {
+        host: '127.0.0.1',
+        socksPort: 1080,
+        httpPort: 8080,
+        httpsPort: 8443,
+      },
+      auth: {
+        username: 'alice',
+        password: 'schema-sync-password',
+      },
+      access: {
+        mode: 'published-routes',
+        allowUnsafePublicEmptyPassword: false,
+      },
+      exposure: {
+        mode: 'loopback',
+        allowLan: false,
+        baseDomain: null,
+      },
+      location: {
+        requested: 'se-sto',
+        country: 'Sweden',
+        city: 'Stockholm',
+        hostnameLabel: 'se-sto',
+        resolvedAlias: null,
+      },
+      https: {
+        enabled: false,
+      },
+    },
+    mullvad: {
+      accountNumber: '123456789012',
+      deviceName: 'mullgate-test-host',
+      lastProvisionedAt: null,
+      relayConstraints: {
+        ownership: 'mullvad-owned',
+        providers: ['31173'],
+      },
+      wireguard: {
+        publicKey: 'public-key-value',
+        privateKey: 'schema-sync-private-key',
+        ipv4Address: null,
+        ipv6Address: null,
+        gatewayIpv4: null,
+        gatewayIpv6: null,
+        dnsServers: ['10.64.0.1'],
+        peerPublicKey: null,
+        peerEndpoint: null,
+      },
+    },
+    routing: {
+      locations: [
+        createFixtureRoute({
+          alias: 'se-sto',
+          hostname: 'se-sto',
+          bindIp: '127.0.0.1',
+          requested: 'se-sto',
+          country: 'Sweden',
+          city: 'Stockholm',
+          hostnameLabel: 'se-sto',
+          resolvedAlias: null,
+          providers: ['31173'],
+          exit: {
+            countryCode: 'se',
+            cityCode: 'sto',
+          },
+        }),
+      ],
+    },
+    runtime: createFixtureRuntime({
+      paths,
+      status: {
+        phase: 'unvalidated',
+        lastCheckedAt: null,
+        message: 'Pending first render.',
+      },
+    }),
+    diagnostics: {
+      lastRuntimeStartReportPath: paths.runtimeStartDiagnosticsFile,
+      lastRuntimeStart: null,
+    },
+  });
+}


### PR DESCRIPTION
Three hardening fixes addressing findings from #18:

1. **Redaction schema-sync** — centralized sensitive field paths into `sensitiveConfigFieldPaths` const in schema.ts, refactored collectKnownSecrets() to derive from it (single source of truth), added sync-verification test.

2. **Unpredictable temp file names** — replaced `Date.now()` with `crypto.randomBytes(4).readUInt32LE()` in writeFileAtomic() for defense-in-depth against symlink attacks.

3. **Public exposure warning** — added console.warn() when allowUnsafePublicEmptyPassword=true + public mode + empty password. Non-blocking, just loud.

All 121 tests pass.