### PR TITLE
feat(cli): add runtime control commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [1.3.0] - 2026-04-08
+
+### Added
+
+- `mullgate proxy stop`, `mullgate proxy restart`, `mullgate proxy logs`, `mullgate version`, and `mullgate completions <bash|zsh|fish>` for day-two runtime control, support reporting, and shell integration
+- an env-gated end-to-end runtime test that exercises the real `setup -> start -> status -> doctor -> stop` operator path when live Mullvad credentials are available
+
+### Changed
+
+- `mullgate proxy start` now supports `--dry-run` so operators can rerender and validate runtime artifacts without launching Docker
+- relay list output now renders as an aligned table, and stale saved relay catalogs now opportunistically refresh during `mullgate proxy start`
+- README, usage docs, hosted docs command reference, and the bundled operator skill now document the expanded runtime-control and support-command surface
+- docs home now includes an interactive terminal walkthrough and the docs search trigger is enabled in the hosted layout
+- build output now ships source maps and Vitest now enforces coverage thresholds for the repo
+
+### Fixed
+
+- bash, zsh, and fish completion generation now matches the actual `mullgate config path` command instead of advertising a non-existent `config paths` subcommand
+
 ## [1.2.1] - 2026-04-02
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,24 @@ make install
 make release-check
 ```
 
+## Technical architecture
+
+- `src/cli.ts` wires the top-level command tree.
+- `src/commands/` owns operator-facing CLI flows such as setup, proxy runtime control, status, doctor, relay inspection, and advanced config editing.
+- `src/app/setup-runner.ts` contains the guided/non-interactive setup orchestration that provisions Mullvad credentials, resolves route selections, writes relay cache state, and persists the canonical config.
+- `src/config/` defines the schema, canonical storage normalization, redaction rules, and exposure contract that every command reads from.
+- `src/runtime/` renders and validates the shared Docker runtime bundle: wireproxy config, route-proxy config, docker-compose manifest, and typed compose status checks.
+- `src/mullvad/` is the upstream integration layer for relay catalog fetches, WireGuard provisioning, and exact-exit probing.
+- `src/domain/` holds location alias and region-group logic that stays independent from CLI concerns.
+- `test/cli/` covers the operator contract. `test/runtime/`, `test/config/`, `test/domain/`, and `test/mullvad-*` cover the lower-level behavior that command flows compose.
+
+## Data flow
+
+1. `mullgate setup` collects input, talks to Mullvad, resolves route aliases, and writes a canonical `config.json` plus relay cache and derived runtime artifacts.
+2. `mullgate proxy start` reloads that saved config, rerenders the runtime bundle, validates it, and then launches Docker Compose.
+3. `mullgate proxy status` and `mullgate proxy doctor` combine saved config state, rendered artifacts, validation reports, and live Docker Compose state into operator-facing diagnostics.
+4. Config mutations such as `mullgate config set` or `mullgate proxy access` update the canonical config first, then ask the operator to refresh derived runtime artifacts when required.
+
 ## Maintainer docs
 
 Use these docs when you are changing the docs site, cutting a release, or publishing `mullgate`:

--- a/README.md
+++ b/README.md
@@ -55,13 +55,19 @@ flowchart TB
         export[mullgate proxy export]
         exportRegions[mullgate proxy export --regions]
         relays[mullgate proxy relay list or probe]
-        recommend[mullgate proxy relay recommend]
-        validate[mullgate proxy validate --refresh]
-        start[mullgate proxy start]
-        status[mullgate proxy status]
-        doctor[mullgate proxy doctor]
-        autostart[mullgate proxy autostart]
-        path[mullgate config path]
+    recommend[mullgate proxy relay recommend]
+    validate[mullgate proxy validate --refresh]
+    start[mullgate proxy start]
+    dryRun[mullgate proxy start --dry-run]
+    stop[mullgate proxy stop]
+    restart[mullgate proxy restart]
+    status[mullgate proxy status]
+    logs[mullgate proxy logs]
+    doctor[mullgate proxy doctor]
+    autostart[mullgate proxy autostart]
+    version[mullgate version]
+    completions[mullgate completions bash]
+    path[mullgate config path]
     end
 
     subgraph state[Canonical config and saved state]
@@ -105,9 +111,15 @@ flowchart TB
     operator --> recommend
     operator --> validate
     operator --> start
+    operator --> dryRun
+    operator --> stop
+    operator --> restart
     operator --> status
+    operator --> logs
     operator --> doctor
     operator --> autostart
+    operator --> version
+    operator --> completions
     operator --> path
 
     setup --> config
@@ -203,8 +215,10 @@ mullgate setup --non-interactive
 mullgate proxy access
 mullgate proxy export --regions
 mullgate proxy export --guided
+mullgate proxy start --dry-run
 mullgate proxy start
 mullgate proxy status
+mullgate proxy logs --tail 50
 mullgate proxy doctor
 ```
 
@@ -238,14 +252,21 @@ macOS and Windows can install the CLI and report config/runtime state truthfully
 | `mullgate proxy relay recommend` | `--country`, `--count`, `--apply` | preview or pin an exact relay choice |
 | `mullgate proxy relay verify` | `--route` | verify a configured route across the published proxy protocols |
 | `mullgate proxy validate` | `--refresh` | refresh saved validation metadata and config-derived artifacts |
-| `mullgate proxy start` | none | launch the runtime |
+| `mullgate proxy start` | `--dry-run` | render and validate artifacts, then optionally launch the runtime |
+| `mullgate proxy stop` | none | stop the saved Docker runtime bundle without rerendering artifacts |
+| `mullgate proxy restart` | none | stop the current bundle, rerender artifacts, and start it again |
 | `mullgate proxy status` | none | inspect live runtime state |
+| `mullgate proxy logs` | `--tail`, `--follow` | read the saved Docker Compose logs for the current runtime bundle |
 | `mullgate proxy doctor` | none | diagnose routing, hostname, and runtime failures |
 | `mullgate proxy autostart` | `enable`, `disable`, `status` | manage login-time startup on supported platforms |
 | `mullgate config path` | none | print config, state, cache, and runtime paths |
 | `mullgate config show` | none | print the saved canonical config |
 | `mullgate config get` | `<key>` | read one saved config value |
 | `mullgate config set` | `<key> <value>` | update one saved config value |
+| `mullgate version` | none | print CLI version plus support metadata |
+| `mullgate completions <shell>` | `bash`, `zsh`, `fish` | generate shell completion scripts |
+
+for operator workflows, `mullgate proxy start --dry-run` is the safe preflight path before touching Docker, `mullgate proxy logs` is the first live-runtime evidence surface after `status`, and `mullgate proxy restart` is the canonical "rerender + bounce" shortcut once setup is already saved.
 
 ## examples
 

--- a/docs/mullgate-docs/app/(home)/page.tsx
+++ b/docs/mullgate-docs/app/(home)/page.tsx
@@ -1,8 +1,9 @@
 import Link from 'next/link';
+import { TerminalDemo } from '@/components/terminal-demo';
 
 export default function HomePage() {
   return (
-    <main className="mx-auto flex min-h-screen max-w-4xl flex-1 flex-col items-center justify-center px-6 py-16 text-center">
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-1 flex-col items-center justify-center px-6 py-16 text-center">
       <p className="mb-3 text-sm font-medium uppercase tracking-[0.2em] text-fd-muted-foreground">
         Mullgate Documentation
       </p>
@@ -24,6 +25,7 @@ export default function HomePage() {
           Quickstart
         </Link>
       </div>
+      <TerminalDemo />
     </main>
   );
 }

--- a/docs/mullgate-docs/components/terminal-demo.tsx
+++ b/docs/mullgate-docs/components/terminal-demo.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+
+type DemoStep = {
+  readonly id: string;
+  readonly label: string;
+  readonly command: string;
+  readonly output: readonly string[];
+};
+
+const STEPS: readonly DemoStep[] = [
+  {
+    id: 'setup',
+    label: 'Setup',
+    command:
+      'mullgate setup --non-interactive --account-number 123456789012 --username alice --password hunter2 --location se-gothenburg',
+    output: [
+      'Mullgate setup complete.',
+      'phase: setup',
+      'source: guided-setup',
+      'routes: 1',
+      'relay cache: ~/.cache/mullgate/relays.json',
+      'runtime status: validated',
+    ],
+  },
+  {
+    id: 'access',
+    label: 'Access',
+    command: 'mullgate proxy access --mode private-network --base-domain mullgate.tail',
+    output: [
+      'Mullgate proxy access updated.',
+      'mode: private-network',
+      'base domain: mullgate.tail',
+      'shared host: 100.64.0.10',
+      'dns guidance: publish each saved route hostname to the shared host IP',
+    ],
+  },
+  {
+    id: 'start',
+    label: 'Start',
+    command: 'mullgate proxy start --dry-run',
+    output: [
+      'Mullgate runtime dry-run complete.',
+      'phase: validation',
+      'validation: docker/3proxy-startup',
+      'docker launch: skipped (--dry-run)',
+      'runtime status: validated',
+    ],
+  },
+];
+
+export function TerminalDemo() {
+  const [activeId, setActiveId] = useState<string>(STEPS[0].id);
+  const activeStep = STEPS.find((step) => step.id === activeId) ?? STEPS[0];
+
+  if (!activeStep) {
+    return null;
+  }
+
+  return (
+    <section className="mt-12 w-full max-w-4xl rounded-2xl border bg-fd-card text-left shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b px-5 py-4">
+        <div>
+          <p className="text-sm font-semibold">Interactive terminal walkthrough</p>
+          <p className="text-sm text-fd-muted-foreground">
+            Click a step to preview the exact command shape and the operator-facing output.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {STEPS.map((step) => {
+            const active = step.id === activeId;
+
+            return (
+              <button
+                key={step.id}
+                type="button"
+                onClick={() => setActiveId(step.id)}
+                className={[
+                  'rounded-md border px-3 py-1.5 text-sm transition',
+                  active
+                    ? 'border-fd-primary bg-fd-primary text-fd-primary-foreground'
+                    : 'border-fd-border bg-fd-background hover:bg-fd-muted',
+                ].join(' ')}
+              >
+                {step.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto bg-[#09101a] px-5 py-4 text-sm text-slate-100">
+        <div className="mb-4 flex items-center gap-2">
+          <span className="h-3 w-3 rounded-full bg-red-400" />
+          <span className="h-3 w-3 rounded-full bg-yellow-400" />
+          <span className="h-3 w-3 rounded-full bg-emerald-400" />
+        </div>
+        <pre className="whitespace-pre-wrap break-words font-mono leading-7">
+          <span className="text-emerald-300">$ </span>
+          {activeStep.command}
+          {'\n'}
+          {activeStep.output.join('\n')}
+        </pre>
+      </div>
+    </section>
+  );
+}

--- a/docs/mullgate-docs/content/docs/guides/usage.mdx
+++ b/docs/mullgate-docs/content/docs/guides/usage.mdx
@@ -8,11 +8,14 @@ This guide expands on the consumer-facing repository `README`. It keeps the deep
 - `mullgate --help`
 - `mullgate setup --help`
 - `mullgate proxy start --help`
+- `mullgate proxy logs --help`
 - `mullgate proxy status --help`
 - `mullgate proxy doctor --help`
 - `mullgate proxy relay --help`
 - `mullgate proxy relay recommend --help`
 - `mullgate config --help`
+- `mullgate version --help`
+- `mullgate completions --help`
 
 ## Install forms
 
@@ -183,6 +186,47 @@ If an installed `mullgate` command reports an unsupported config version:
 - rerun `mullgate proxy start`
 
 Do not expect the current CLI to keep operating on an older runtime bundle in place.
+
+## Runtime control and support utilities
+
+Use these commands after setup when you need to preflight, stop, restart, inspect, or hand support metadata to someone else.
+
+### Dry-run the rendered runtime bundle
+
+```bash
+mullgate proxy start --dry-run
+```
+
+Use this before touching Docker when you want Mullgate to rerender and validate the runtime artifacts but stop short of launching containers.
+
+### Stop or restart the saved bundle
+
+```bash
+mullgate proxy stop
+mullgate proxy restart
+```
+
+- `proxy stop` is the canonical clean shutdown for the saved runtime bundle
+- `proxy restart` is the canonical "stop, rerender, and start again" shortcut after a config or relay change
+
+### Read the saved Docker Compose logs
+
+```bash
+mullgate proxy logs --tail 200
+mullgate proxy logs --tail 50 --follow
+```
+
+Use `mullgate proxy logs` right after `mullgate proxy status` when a runtime looks unhealthy and you want evidence from the saved bundle instead of guessing.
+
+### Print support metadata or install shell completions
+
+```bash
+mullgate version
+mullgate completions bash > ~/.local/share/bash-completion/completions/mullgate
+```
+
+- `mullgate version` prints the CLI version, config schema, Node version, platform, architecture, and hostname for support reports
+- `mullgate completions <bash|zsh|fish>` prints shell completion scripts to stdout so you can install them in the shell-specific location you already use
 
 ## Exporting proxy lists for clients
 

--- a/docs/mullgate-docs/content/docs/reference/commands.mdx
+++ b/docs/mullgate-docs/content/docs/reference/commands.mdx
@@ -8,8 +8,12 @@ The documentation repeatedly anchors itself to the following CLI help contract:
 - `mullgate --help`
 - `mullgate setup --help`
 - `mullgate proxy --help`
+- `mullgate proxy start --help`
+- `mullgate proxy logs --help`
 - `mullgate proxy relay --help`
 - `mullgate config --help`
+- `mullgate version --help`
+- `mullgate completions --help`
 
 ## Core workflow commands
 
@@ -23,14 +27,19 @@ The documentation repeatedly anchors itself to the following CLI help contract:
 | `mullgate proxy relay recommend` | `--country`, `--count`, `--apply` | preview or pin an exact relay choice |
 | `mullgate proxy relay verify` | `--route` | verify a configured route across the published proxy protocols |
 | `mullgate proxy validate` | `--refresh` | refresh saved validation metadata and config-derived artifacts |
-| `mullgate proxy start` | none | launch the runtime |
+| `mullgate proxy start` | `--dry-run` | render and validate artifacts, then optionally launch the runtime |
+| `mullgate proxy stop` | none | stop the saved Docker runtime bundle without rerendering artifacts |
+| `mullgate proxy restart` | none | stop the current runtime bundle, rerender artifacts, and start it again |
 | `mullgate proxy status` | none | inspect live runtime state |
+| `mullgate proxy logs` | `--tail`, `--follow` | read the saved Docker Compose logs for the current runtime bundle |
 | `mullgate proxy doctor` | none | diagnose routing, hostname, and runtime failures |
 | `mullgate proxy autostart` | `enable`, `disable`, `status` | manage Linux user-service startup, including linger-backed reboot startup |
 | `mullgate config path` | none | print config, state, cache, and runtime paths |
 | `mullgate config show` | none | print the saved canonical config |
 | `mullgate config get` | `<key>` | read one saved config value |
 | `mullgate config set` | `<key> <value>` | update one saved config value |
+| `mullgate version` | none | print CLI version plus support metadata |
+| `mullgate completions <shell>` | `bash`, `zsh`, `fish` | generate shell completion scripts |
 
 ## Invocation forms
 
@@ -52,9 +61,12 @@ A practical workflow usually looks like this:
 7. `mullgate proxy relay recommend`
 8. `mullgate proxy access`
 9. `mullgate proxy validate --refresh`
-10. `mullgate proxy start`
-11. `mullgate proxy status`
-12. `mullgate proxy doctor`
+10. `mullgate proxy start --dry-run`
+11. `mullgate proxy start`
+12. `mullgate proxy status`
+13. `mullgate proxy logs --tail 50`
+14. `mullgate proxy doctor`
+15. `mullgate proxy restart` when you need a stop-plus-rerender cycle later
 
 If you switch to `inline-selector`, skip `mullgate proxy export` and use `mullgate proxy access` to inspect the shared listener and selector examples. For the supported selector families and guaranteed URL shape, see [Inline Selector Reference](/docs/guides/inline-selector-selectors).
 

--- a/docs/mullgate-docs/lib/layout.shared.tsx
+++ b/docs/mullgate-docs/lib/layout.shared.tsx
@@ -21,6 +21,9 @@ export function baseOptions(): BaseLayoutProps {
       },
     ],
     githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
+    searchToggle: {
+      enabled: true,
+    },
     slots: {
       themeSwitch: MullvadThemeSwitch,
     },

--- a/docs/mullgate-docs/pnpm-lock.yaml
+++ b/docs/mullgate-docs/pnpm-lock.yaml
@@ -12,14 +12,14 @@ importers:
         specifier: ^0.73.1
         version: 0.73.1
       fumadocs-core:
-        specifier: 16.7.4
-        version: 16.7.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        specifier: 16.7.9
+        version: 16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       fumadocs-mdx:
         specifier: 14.2.11
-        version: 14.2.11(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.7.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 14.2.11(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-ui:
-        specifier: 16.7.4
-        version: 16.7.4(@takumi-rs/image-response@0.73.1)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.7.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(shiki@4.0.2)(tailwindcss@4.2.2)
+        specifier: 16.7.9
+        version: 16.7.9(@takumi-rs/image-response@0.73.1)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(shiki@4.0.2)(tailwindcss@4.2.2)
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)
@@ -58,8 +58,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(jiti@2.6.1)
       eslint-config-next:
-        specifier: 16.2.1
-        version: 16.2.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 16.2.2
+        version: 16.2.2(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       postcss:
         specifier: ^8.5.8
         version: 8.5.8
@@ -545,8 +545,8 @@ packages:
   '@next/env@16.2.1':
     resolution: {integrity: sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==}
 
-  '@next/eslint-plugin-next@16.2.1':
-    resolution: {integrity: sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA==}
+  '@next/eslint-plugin-next@16.2.2':
+    resolution: {integrity: sha512-IOPbWzDQ+76AtjZioaCjpIY72xNSDMnarZ2GMQ4wjNLvnJEJHqxQwGFhgnIWLV9klb4g/+amg88Tk5OXVpyLTw==}
 
   '@next/swc-darwin-arm64@16.2.1':
     resolution: {integrity: sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==}
@@ -1703,8 +1703,8 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  eslint-config-next@16.2.1:
-    resolution: {integrity: sha512-qhabwjQZ1Mk53XzXvmogf8KQ0tG0CQXF0CZ56+2/lVhmObgmaqj7x5A1DSrWdZd3kwI7GTPGUjFne+krRxYmFg==}
+  eslint-config-next@16.2.2:
+    resolution: {integrity: sha512-6VlvEhwoug2JpVgjZDhyXrJXUEuPY++TddzIpTaIRvlvlXXFgvQUtm3+Zr84IjFm0lXtJt73w19JA08tOaZVwg==}
     peerDependencies:
       eslint: '>=9.0.0'
       typescript: '>=3.3.1'
@@ -1908,8 +1908,8 @@ packages:
       react-dom:
         optional: true
 
-  fumadocs-core@16.7.4:
-    resolution: {integrity: sha512-AwRmfYVN3dJm8RuVVSSKj/1zBby3f83nGFl67YyCwmLtpna5iJNIbLtR0cTLyKUXWfHC3J99riEqYl6NOgUsKw==}
+  fumadocs-core@16.7.9:
+    resolution: {integrity: sha512-/BvCNp7Aq76Y4X7uuSPDcYgBSp/fgqjIeUR/kL+8Roy0xo1x/J2Vj/+o1fsdw1I9tvw2cIeFtb6BVMRaKZttFw==}
     peerDependencies:
       '@mdx-js/mdx': '*'
       '@mixedbread/sdk': ^0.46.0
@@ -1998,13 +1998,13 @@ packages:
       vite:
         optional: true
 
-  fumadocs-ui@16.7.4:
-    resolution: {integrity: sha512-dfjRbx/MXzD+UXCV80C5rg7u7IYpU9bkkJUNeGRBBD7HTh9civSdiditQPwgJF6nloNYWMhfiRKWmcDBsEwyZg==}
+  fumadocs-ui@16.7.9:
+    resolution: {integrity: sha512-FBYimmM14v5bu3VqI05YD/O+f3GmWrIpRkkW9gjILhJfQJwElMmVlem9HVzUlQcLZPRyxS6i0BmW7EKSOiI6gw==}
     peerDependencies:
       '@takumi-rs/image-response': '*'
       '@types/mdx': '*'
       '@types/react': '*'
-      fumadocs-core: 16.7.4
+      fumadocs-core: 16.7.9
       next: 16.x.x
       react: ^19.2.0
       react-dom: ^19.2.0
@@ -2440,6 +2440,11 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lucide-react@1.7.0:
+    resolution: {integrity: sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -2774,8 +2779,8 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3707,7 +3712,7 @@ snapshots:
 
   '@next/env@16.2.1': {}
 
-  '@next/eslint-plugin-next@16.2.1':
+  '@next/eslint-plugin-next@16.2.2':
     dependencies:
       fast-glob: 3.3.1
 
@@ -4908,9 +4913,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.2.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.2.2(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.2.1
+      '@next/eslint-plugin-next': 16.2.2
       eslint: 10.1.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.1.0(jiti@2.6.1))
@@ -5203,7 +5208,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  fumadocs-core@16.7.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6):
+  fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.2
       '@orama/orama': 3.1.18
@@ -5218,7 +5223,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       negotiator: 1.0.0
       npm-to-yarn: 3.0.1
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
       remark: 15.0.1
       remark-gfm: 4.0.1
       remark-rehype: 11.1.2
@@ -5242,14 +5247,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.11(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.7.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  fumadocs-mdx@14.2.11(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.4
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.7.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -5271,7 +5276,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.7.4(@takumi-rs/image-response@0.73.1)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.7.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(shiki@4.0.2)(tailwindcss@4.2.2):
+  fumadocs-ui@16.7.9(@takumi-rs/image-response@0.73.1)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(shiki@4.0.2)(tailwindcss@4.2.2):
     dependencies:
       '@fumadocs/tailwind': 0.0.3(tailwindcss@4.2.2)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -5285,8 +5290,8 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.7.4(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
-      lucide-react: 0.577.0(react@19.2.4)
+      fumadocs-core: 16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.577.0(react@19.2.4))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      lucide-react: 1.7.0(react@19.2.4)
       motion: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -5778,6 +5783,10 @@ snapshots:
       yallist: 3.1.1
 
   lucide-react@0.577.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
+  lucide-react@1.7.0(react@19.2.4):
     dependencies:
       react: 19.2.4
 
@@ -6392,7 +6401,7 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.2: {}
 
   picocolors@1.1.1: {}
 

--- a/docs/pr17-idea-audit.md
+++ b/docs/pr17-idea-audit.md
@@ -1,0 +1,40 @@
+# PR 17 Idea Audit
+
+Status of each idea from `nightshift-idea-generator.md` after auditing current `main` and this branch.
+
+## Implemented in this branch
+
+- `H-03` - Added an env-gated real-runtime E2E flow in `test/e2e/full-runtime.test.ts`. It exercises `setup -> proxy start -> proxy status -> proxy doctor -> proxy stop` when `MULLGATE_E2E=1` and live credentials are provided.
+- `H-07` - Added `mullgate proxy stop`.
+- `M-01` - Added `mullgate proxy restart`.
+- `M-02` - `proxy start` now opportunistically refreshes stale relay cache data before rendering runtime artifacts when a fresh relay fetch succeeds.
+- `M-03` - Added `mullgate proxy start --dry-run`.
+- `M-04` - Deduplicated `WritableTextSink` into `src/cli-output.ts`.
+- `M-06` - Added coverage thresholds in `vitest.config.ts`.
+- `M-09` - Added explicit runtime remediation text to start/stop failure surfaces.
+- `M-11` - Added `mullgate completions <bash|zsh|fish>`.
+- `L-02` - Added architecture and data-flow guidance to `CONTRIBUTING.md`.
+- `L-03` - Enabled build source maps in `tsconfig.build.json`.
+- `L-04` - Added `mullgate version`.
+- `L-05` - Added `mullgate proxy logs`.
+- `L-07` - Switched relay listing to aligned table output.
+- `D-01` - Added a lightweight interactive terminal walkthrough on the docs homepage.
+- `D-02` - Enabled the docs search trigger in the docs layout options.
+
+## Already implemented on main
+
+- `M-07` - The no-op `sanitizeText()` issue was already fixed by merged PR `#23`.
+
+## Rejected after audit
+
+- `H-01` - Splitting `start.ts` right now would be mostly churn. The branch already adds user-facing runtime controls and tests; a large no-behavior refactor was not justified in the same patch.
+- `H-02` - Config-at-rest encryption was rejected for now. Without a stable key-management story for unattended CLI use, it would trade plaintext-on-disk for brittle operator workflows and false confidence.
+- `H-04` - A shared `Result<T, E>` library was rejected in this pass. It is a broad internal-style rewrite with low operator value compared to the concrete runtime/workflow gaps addressed here.
+- `H-05` - Full structured logging with verbosity tiers and JSON output was rejected for now. It needs a repo-wide output contract redesign, not a piecemeal command patch.
+- `H-06` - Splitting `setup-runner.ts` was rejected in this pass for the same reason as `H-01`: broad churn without a pressing user-facing bug.
+- `M-05` - Automatic config migrations were rejected because Mullgate intentionally treats unsupported configs as stale local state and fails fast with explicit recovery steps.
+- `M-08` - A separate `config diff` surface was rejected for now. Existing `config show`, `config get`, and the refreshed artifact diagnostics cover the current operator need better than another editing DSL.
+- `M-10` - DNS-over-HTTPS and an insecure TLS bypass flag were rejected. The fetch path already uses strict TLS defaults, and adding a skip-verify escape hatch would be a security regression.
+- `L-01` - Blanket JSDoc on all exported symbols was rejected as low-signal churn.
+- `L-06` - Extra pnpm-store caching was rejected. CI already uses `actions/setup-node` with `cache: pnpm`, which is sufficient for this repo.
+- `L-08` - Non-TTY progress indicators were rejected for now. They add output noise and a new reporting contract without fixing a current operator problem.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,12 +5,15 @@ This guide expands on the consumer-facing repository [README](../README.md). It 
 - `mullgate --help`
 - `mullgate setup --help`
 - `mullgate proxy start --help`
+- `mullgate proxy logs --help`
 - `mullgate proxy status --help`
 - `mullgate proxy doctor --help`
 - `mullgate proxy autostart --help`
 - `mullgate proxy relay --help`
 - `mullgate proxy relay recommend --help`
 - `mullgate config --help`
+- `mullgate version --help`
+- `mullgate completions --help`
 
 ## Install forms
 
@@ -186,6 +189,47 @@ If an installed `mullgate` command reports an unsupported config version:
 - rerun `mullgate proxy start`
 
 Do not expect the current CLI to keep operating on an older runtime bundle in place.
+
+## Runtime control and support utilities
+
+Use these commands after setup when you need to preflight, stop, restart, inspect, or hand support metadata to someone else.
+
+### Dry-run the rendered runtime bundle
+
+```bash
+mullgate proxy start --dry-run
+```
+
+Use this before touching Docker when you want Mullgate to rerender and validate the runtime artifacts but stop short of launching containers.
+
+### Stop or restart the saved bundle
+
+```bash
+mullgate proxy stop
+mullgate proxy restart
+```
+
+- `proxy stop` is the canonical clean shutdown for the saved runtime bundle
+- `proxy restart` is the canonical "stop, rerender, and start again" shortcut after a config or relay change
+
+### Read the saved Docker Compose logs
+
+```bash
+mullgate proxy logs --tail 200
+mullgate proxy logs --tail 50 --follow
+```
+
+Use `mullgate proxy logs` right after `mullgate proxy status` when a runtime looks unhealthy and you want evidence from the saved bundle instead of guessing.
+
+### Print support metadata or install shell completions
+
+```bash
+mullgate version
+mullgate completions bash > ~/.local/share/bash-completion/completions/mullgate
+```
+
+- `mullgate version` prints the CLI version, config schema, Node version, platform, architecture, and hostname for support reports
+- `mullgate completions <bash|zsh|fish>` prints shell completion scripts to stdout so you can install them in the shell-specific location you already use
 
 ## Relay discovery, recommendation, and exit verification
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mullgate",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": "Microck",
   "keywords": [
     "mullvad",

--- a/package.json
+++ b/package.json
@@ -68,13 +68,19 @@
   "devDependencies": {
     "@biomejs/biome": "2.2.6",
     "@types/node": "^24.10.1",
-    "@vitest/coverage-v8": "4.1.1",
+    "@vitest/coverage-v8": "4.1.3",
     "simple-git-hooks": "2.13.1",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.1"
+    "vite": "8.0.7",
+    "vitest": "^4.1.3"
   },
   "packageManager": "pnpm@10.18.3",
+  "pnpm": {
+    "overrides": {
+      "vite": "8.0.7"
+    }
+  },
   "simple-git-hooks": {
     "pre-commit": "pnpm lint && pnpm typecheck"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  vite: 8.0.7
+
 importers:
 
   .:
@@ -25,8 +28,8 @@ importers:
         specifier: ^24.10.1
         version: 24.12.0
       '@vitest/coverage-v8':
-        specifier: 4.1.1
-        version: 4.1.1(vitest@4.1.1(@types/node@24.12.0)(vite@8.0.1(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0)))
+        specifier: 4.1.3
+        version: 4.1.3(vitest@4.1.3)
       simple-git-hooks:
         specifier: 2.13.1
         version: 2.13.1
@@ -36,9 +39,12 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vite:
+        specifier: 8.0.7
+        version: 8.0.7(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0)
       vitest:
-        specifier: ^4.1.1
-        version: 4.1.1(@types/node@24.12.0)(vite@8.0.1(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0))
+        specifier: ^4.1.3
+        version: 4.1.3(@types/node@24.12.0)(@vitest/coverage-v8@4.1.3)(vite@8.0.7(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0))
 
 packages:
 
@@ -297,103 +303,106 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+  '@napi-rs/wasm-runtime@1.1.3':
+    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
-  '@oxc-project/types@0.120.0':
-    resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
+  '@oxc-project/types@0.123.0':
+    resolution: {integrity: sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.10':
-    resolution: {integrity: sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
-    resolution: {integrity: sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
-    resolution: {integrity: sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
+    resolution: {integrity: sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
-    resolution: {integrity: sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
+    resolution: {integrity: sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
-    resolution: {integrity: sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
+    resolution: {integrity: sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
-    resolution: {integrity: sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
+    resolution: {integrity: sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
-    resolution: {integrity: sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
-    resolution: {integrity: sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
+    resolution: {integrity: sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
-    resolution: {integrity: sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
-    resolution: {integrity: sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
+    resolution: {integrity: sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
-    resolution: {integrity: sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
+    resolution: {integrity: sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
-    resolution: {integrity: sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
+    resolution: {integrity: sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.10':
-    resolution: {integrity: sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==}
+  '@rolldown/pluginutils@1.0.0-rc.13':
+    resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -413,43 +422,43 @@ packages:
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
-  '@vitest/coverage-v8@4.1.1':
-    resolution: {integrity: sha512-nZ4RWwGCoGOQRMmU/Q9wlUY540RVRxJZ9lxFsFfy0QV7Zmo5VVBhB6Sl9Xa0KIp2iIs3zWfPlo9LcY1iqbpzCw==}
+  '@vitest/coverage-v8@4.1.3':
+    resolution: {integrity: sha512-/MBdrkA8t6hbdCWFKs09dPik774xvs4Z6L4bycdCxYNLHM8oZuRyosumQMG19LUlBsB6GeVpL1q4kFFazvyKGA==}
     peerDependencies:
-      '@vitest/browser': 4.1.1
-      vitest: 4.1.1
+      '@vitest/browser': 4.1.3
+      vitest: 4.1.3
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.1':
-    resolution: {integrity: sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==}
+  '@vitest/expect@4.1.3':
+    resolution: {integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==}
 
-  '@vitest/mocker@4.1.1':
-    resolution: {integrity: sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==}
+  '@vitest/mocker@4.1.3':
+    resolution: {integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: 8.0.7
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.1':
-    resolution: {integrity: sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==}
+  '@vitest/pretty-format@4.1.3':
+    resolution: {integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==}
 
-  '@vitest/runner@4.1.1':
-    resolution: {integrity: sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==}
+  '@vitest/runner@4.1.3':
+    resolution: {integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==}
 
-  '@vitest/snapshot@4.1.1':
-    resolution: {integrity: sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==}
+  '@vitest/snapshot@4.1.3':
+    resolution: {integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==}
 
-  '@vitest/spy@4.1.1':
-    resolution: {integrity: sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==}
+  '@vitest/spy@4.1.3':
+    resolution: {integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==}
 
-  '@vitest/utils@4.1.1':
-    resolution: {integrity: sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==}
+  '@vitest/utils@4.1.3':
+    resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -625,15 +634,15 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  rolldown@1.0.0-rc.10:
-    resolution: {integrity: sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==}
+  rolldown@1.0.0-rc.13:
+    resolution: {integrity: sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -669,12 +678,12 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.4:
-    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -697,14 +706,14 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  vite@8.0.1:
-    resolution: {integrity: sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==}
+  vite@8.0.7:
+    resolution: {integrity: sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -740,21 +749,23 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.1:
-    resolution: {integrity: sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==}
+  vitest@4.1.3:
+    resolution: {integrity: sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.1
-      '@vitest/browser-preview': 4.1.1
-      '@vitest/browser-webdriverio': 4.1.1
-      '@vitest/ui': 4.1.1
+      '@vitest/browser-playwright': 4.1.3
+      '@vitest/browser-preview': 4.1.3
+      '@vitest/browser-webdriverio': 4.1.3
+      '@vitest/coverage-istanbul': 4.1.3
+      '@vitest/coverage-v8': 4.1.3
+      '@vitest/ui': 4.1.3
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: 8.0.7
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -767,6 +778,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -947,63 +962,65 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@napi-rs/wasm-runtime@1.1.1':
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
     dependencies:
       '@emnapi/core': 1.9.1
       '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@oxc-project/types@0.120.0': {}
+  '@oxc-project/types@0.123.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.10':
+  '@rolldown/binding-android-arm64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.10': {}
+  '@rolldown/pluginutils@1.0.0-rc.13': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -1025,10 +1042,10 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@vitest/coverage-v8@4.1.1(vitest@4.1.1(@types/node@24.12.0)(vite@8.0.1(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0)))':
+  '@vitest/coverage-v8@4.1.3(vitest@4.1.3)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.1
+      '@vitest/utils': 4.1.3
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -1037,46 +1054,46 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.1(@types/node@24.12.0)(vite@8.0.1(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0))
+      vitest: 4.1.3(@types/node@24.12.0)(@vitest/coverage-v8@4.1.3)(vite@8.0.7(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0))
 
-  '@vitest/expect@4.1.1':
+  '@vitest/expect@4.1.3':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.1
-      '@vitest/utils': 4.1.1
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.1(vite@8.0.1(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.3(vite@8.0.7(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0))':
     dependencies:
-      '@vitest/spy': 4.1.1
+      '@vitest/spy': 4.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.1(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0)
+      vite: 8.0.7(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0)
 
-  '@vitest/pretty-format@4.1.1':
+  '@vitest/pretty-format@4.1.3':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.1':
+  '@vitest/runner@4.1.3':
     dependencies:
-      '@vitest/utils': 4.1.1
+      '@vitest/utils': 4.1.3
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.1':
+  '@vitest/snapshot@4.1.3':
     dependencies:
-      '@vitest/pretty-format': 4.1.1
-      '@vitest/utils': 4.1.1
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/utils': 4.1.3
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.1': {}
+  '@vitest/spy@4.1.3': {}
 
-  '@vitest/utils@4.1.1':
+  '@vitest/utils@4.1.3':
     dependencies:
-      '@vitest/pretty-format': 4.1.1
+      '@vitest/pretty-format': 4.1.3
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -1236,7 +1253,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.8:
+  postcss@8.5.9:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -1244,26 +1261,26 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  rolldown@1.0.0-rc.10:
+  rolldown@1.0.0-rc.13:
     dependencies:
-      '@oxc-project/types': 0.120.0
-      '@rolldown/pluginutils': 1.0.0-rc.10
+      '@oxc-project/types': 0.123.0
+      '@rolldown/pluginutils': 1.0.0-rc.13
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.10
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.10
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.10
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.10
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.10
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.10
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.10
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.10
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.10
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.10
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.10
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.10
+      '@rolldown/binding-android-arm64': 1.0.0-rc.13
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.13
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.13
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.13
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.13
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.13
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.13
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.13
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.13
 
   semver@7.7.4: {}
 
@@ -1285,9 +1302,9 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.4: {}
+  tinyexec@1.1.1: {}
 
-  tinyglobby@0.2.15:
+  tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -1308,28 +1325,28 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  vite@8.0.1(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0):
+  vite@8.0.7(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.10
-      tinyglobby: 0.2.15
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.13
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 24.12.0
       esbuild: 0.27.4
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@4.1.1(@types/node@24.12.0)(vite@8.0.1(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0)):
+  vitest@4.1.3(@types/node@24.12.0)(@vitest/coverage-v8@4.1.3)(vite@8.0.7(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0)):
     dependencies:
-      '@vitest/expect': 4.1.1
-      '@vitest/mocker': 4.1.1(vite@8.0.1(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0))
-      '@vitest/pretty-format': 4.1.1
-      '@vitest/runner': 4.1.1
-      '@vitest/snapshot': 4.1.1
-      '@vitest/spy': 4.1.1
-      '@vitest/utils': 4.1.1
+      '@vitest/expect': 4.1.3
+      '@vitest/mocker': 4.1.3(vite@8.0.7(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/runner': 4.1.3
+      '@vitest/snapshot': 4.1.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -1338,13 +1355,14 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.1(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0)
+      vite: 8.0.7(@types/node@24.12.0)(esbuild@0.27.4)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.0
+      '@vitest/coverage-v8': 4.1.3(vitest@4.1.3)
     transitivePeerDependencies:
       - msw
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-mullgate
-description: Install, configure, expose, verify, and troubleshoot Mullgate as an operator on a real machine. Use when the request is to actually use Mullgate rather than develop the Mullgate codebase, including first-run setup, non-interactive setup, Tailscale or private-network exposure, inline-selector access, proxy export, relay discovery or recommendation, exact-exit verification, and Linux autostart.
+description: Install, configure, expose, verify, and troubleshoot Mullgate as an operator on a real machine. Use when the request is to actually use Mullgate rather than develop the Mullgate codebase, including first-run setup, non-interactive setup, Tailscale or private-network exposure, inline-selector access, proxy export, relay discovery or recommendation, exact-exit verification, runtime logs and restarts, version/completion reporting, and Linux autostart.
 ---
 
 # Use Mullgate
@@ -60,17 +60,27 @@ Map the request before choosing commands:
 - "Give me a proxy list or file I can import elsewhere"
   - keep or switch to `published-routes`
   - use `mullgate proxy export`
+- "Validate what start would render without touching Docker"
+  - use `mullgate proxy start --dry-run`
+- "Restart the saved runtime cleanly"
+  - use `mullgate proxy restart`
+- "Stop the runtime" or "show me the container logs"
+  - use `mullgate proxy stop` or `mullgate proxy logs --tail 200`
 - "Start automatically after reboot"
   - use `mullgate proxy autostart enable`
   - verify with `mullgate proxy autostart status`
+- "What version is installed?" or "generate shell completion scripts"
+  - use `mullgate version` or `mullgate completions <bash|zsh|fish>`
 
 ## Default Workflow
 
 1. Inspect current posture with `mullgate proxy access`.
 2. Change exposure or access with `mullgate proxy access --mode ... --access-mode ... --route-bind-ip ...` when needed.
-3. Refresh derived state with `mullgate proxy validate --refresh` or restart with `mullgate proxy start`.
-4. Check live/runtime truth with `mullgate proxy status`.
-5. Diagnose failures with `mullgate proxy doctor`.
+3. Preflight the rendered bundle with `mullgate proxy start --dry-run` when runtime changes are risky.
+4. Launch or relaunch with `mullgate proxy start` or `mullgate proxy restart`.
+5. Check live/runtime truth with `mullgate proxy status`.
+6. Pull bundle evidence with `mullgate proxy logs --tail 200`.
+7. Diagnose failures with `mullgate proxy doctor`.
 
 ## Playbooks
 

--- a/src/cli-output.ts
+++ b/src/cli-output.ts
@@ -10,12 +10,12 @@ const ANSI = {
   white: '\u001B[37m',
 } as const;
 
-type WritableTextSink = {
+export type WritableTextSink = {
   write(chunk: string): unknown;
   isTTY?: boolean;
 };
 
-type CliTone = 'info' | 'success' | 'error';
+export type CliTone = 'info' | 'success' | 'error';
 
 export function writeCliReport(input: {
   readonly sink: WritableTextSink;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import packageJson from '../package.json' with { type: 'json' };
 import { writeCliReport } from './cli-output.js';
+import { registerCompletionsCommand } from './commands/completions.js';
 import { registerConfigCommands } from './commands/config.js';
 import { registerProxyCommand } from './commands/proxy.js';
 import { registerSetupCommand } from './commands/setup.js';
+import { registerVersionCommand } from './commands/version.js';
 
 export function createCli(): Command {
   const program = new Command();
@@ -12,11 +15,14 @@ export function createCli(): Command {
   program
     .name('mullgate')
     .description('Minimal Mullvad proxy CLI for setup, daily proxy operations, and advanced config')
+    .version(packageJson.version, '-v, --version', 'display the installed Mullgate CLI version')
     .showHelpAfterError();
 
   registerSetupCommand(program);
   registerProxyCommand(program);
   registerConfigCommands(program);
+  registerVersionCommand(program);
+  registerCompletionsCommand(program);
 
   return program;
 }

--- a/src/commands/autostart.ts
+++ b/src/commands/autostart.ts
@@ -5,15 +5,10 @@ import path from 'node:path';
 
 import type { Command } from 'commander';
 
-import { writeCliReport } from '../cli-output.js';
+import { type WritableTextSink, writeCliReport } from '../cli-output.js';
 import { resolveMullgatePaths } from '../config/paths.js';
 
 const AUTOSTART_UNIT_NAME = 'mullgate.service';
-
-type WritableTextSink = {
-  write(chunk: string): unknown;
-  isTTY?: boolean;
-};
 
 type SystemctlResult = {
   readonly code: number;

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -1,0 +1,151 @@
+import type { Command } from 'commander';
+
+import { type WritableTextSink, writeCliRaw } from '../cli-output.js';
+
+type CompletionShell = 'bash' | 'zsh' | 'fish';
+
+type CompletionsCommandDependencies = {
+  readonly stdout?: WritableTextSink;
+};
+
+const TOP_LEVEL_COMMANDS = ['setup', 'proxy', 'config', 'version', 'completions'] as const;
+const TOP_LEVEL_FLAGS = ['-h', '--help', '-v', '--version'] as const;
+const PROXY_SUBCOMMANDS = [
+  'start',
+  'stop',
+  'restart',
+  'status',
+  'logs',
+  'doctor',
+  'validate',
+  'list',
+  'export',
+  'autostart',
+  'access',
+  'relay',
+] as const;
+const CONFIG_SUBCOMMANDS = ['path', 'show', 'get', 'set', 'validate', 'regions', 'hosts'] as const;
+
+export function registerCompletionsCommand(
+  program: Command,
+  dependencies: CompletionsCommandDependencies = {},
+): void {
+  program
+    .command('completions')
+    .description('Generate shell completion scripts for bash, zsh, or fish.')
+    .argument('<shell>', 'Target shell: bash, zsh, or fish.')
+    .action((shell: string) => {
+      const stdout = dependencies.stdout ?? process.stdout;
+      const normalized = normalizeShell(shell);
+      writeCliRaw({ sink: stdout, text: renderCompletionScript(normalized) });
+    });
+}
+
+function normalizeShell(raw: string): CompletionShell {
+  const normalized = raw.trim().toLowerCase();
+
+  if (normalized === 'bash' || normalized === 'zsh' || normalized === 'fish') {
+    return normalized;
+  }
+
+  throw new Error(`Unsupported shell ${raw}. Expected bash, zsh, or fish.`);
+}
+
+function renderCompletionScript(shell: CompletionShell): string {
+  if (shell === 'bash') {
+    return renderBashScript();
+  }
+
+  if (shell === 'zsh') {
+    return renderZshScript();
+  }
+
+  return renderFishScript();
+}
+
+function renderBashScript(): string {
+  return `# Mullgate bash completions
+_mullgate_complete() {
+  local cur prev words cword
+  _init_completion || return
+
+  local top_level="${TOP_LEVEL_COMMANDS.join(' ')}"
+  local top_level_flags="${TOP_LEVEL_FLAGS.join(' ')}"
+  local proxy_subcommands="${PROXY_SUBCOMMANDS.join(' ')}"
+  local config_subcommands="${CONFIG_SUBCOMMANDS.join(' ')}"
+
+  if [[ $cword -eq 1 ]]; then
+    COMPREPLY=( $(compgen -W "$top_level $top_level_flags" -- "$cur") )
+    return
+  fi
+
+  case "\${words[1]}" in
+    proxy)
+      if [[ $cword -eq 2 ]]; then
+        COMPREPLY=( $(compgen -W "$proxy_subcommands" -- "$cur") )
+        return
+      fi
+      case "\${words[2]}" in
+        start) COMPREPLY=( $(compgen -W "--dry-run --help" -- "$cur") ) ;;
+        stop) COMPREPLY=( $(compgen -W "--help" -- "$cur") ) ;;
+        restart) COMPREPLY=( $(compgen -W "--help" -- "$cur") ) ;;
+        status|doctor|validate|list) COMPREPLY=( $(compgen -W "--help" -- "$cur") ) ;;
+        logs) COMPREPLY=( $(compgen -W "--tail --follow --help" -- "$cur") ) ;;
+        access) COMPREPLY=( $(compgen -W "--mode --access-mode --base-domain --unsafe-public-empty-password --clear-base-domain --route-bind-ip --help" -- "$cur") ) ;;
+        export) COMPREPLY=( $(compgen -W "--protocol --country --region --city --server --provider --owner --run-mode --min-port-speed --count --guided --regions --dry-run --stdout --force --output --help" -- "$cur") ) ;;
+        relay)
+          if [[ $cword -eq 3 ]]; then
+            COMPREPLY=( $(compgen -W "list probe verify recommend" -- "$cur") )
+            return
+          fi
+          ;;
+      esac
+      return
+      ;;
+    config)
+      if [[ $cword -eq 2 ]]; then
+        COMPREPLY=( $(compgen -W "$config_subcommands" -- "$cur") )
+        return
+      fi
+      ;;
+    completions)
+      if [[ $cword -eq 2 ]]; then
+        COMPREPLY=( $(compgen -W "bash zsh fish" -- "$cur") )
+        return
+      fi
+      ;;
+  esac
+}
+
+complete -F _mullgate_complete mullgate
+`;
+}
+
+function renderZshScript(): string {
+  return `#compdef mullgate
+autoload -U bashcompinit
+bashcompinit
+${renderBashScript().replace('complete -F _mullgate_complete mullgate', 'compdef _mullgate_complete mullgate')}`;
+}
+
+function renderFishScript(): string {
+  const lines = [
+    '# Mullgate fish completions',
+    ...TOP_LEVEL_COMMANDS.map(
+      (command) => `complete -c mullgate -f -n "__fish_use_subcommand" -a "${command}"`,
+    ),
+    ...TOP_LEVEL_FLAGS.map(
+      (flag) =>
+        `complete -c mullgate -f -n "__fish_use_subcommand" -l "${flag.replace(/^-+/, '')}"`,
+    ),
+    ...PROXY_SUBCOMMANDS.map(
+      (command) => `complete -c mullgate -f -n "__fish_seen_subcommand_from proxy" -a "${command}"`,
+    ),
+    `complete -c mullgate -n "__fish_seen_subcommand_from completions" -a "bash zsh fish"`,
+    `complete -c mullgate -n "__fish_seen_subcommand_from proxy start" -l dry-run`,
+    `complete -c mullgate -n "__fish_seen_subcommand_from proxy logs" -l tail`,
+    `complete -c mullgate -n "__fish_seen_subcommand_from proxy logs" -l follow`,
+  ];
+
+  return `${lines.join('\n')}\n`;
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,7 +5,7 @@ import { isIP } from 'node:net';
 import type { Command } from 'commander';
 
 import { loadStoredRelayCatalog } from '../app/setup-runner.js';
-import { writeCliReport } from '../cli-output.js';
+import { type WritableTextSink, writeCliReport } from '../cli-output.js';
 import {
   buildExposureContract,
   deriveLoopbackBindIp,
@@ -39,10 +39,6 @@ import {
 
 const ROUTING_LAYER_SERVICE = 'routing-layer';
 const RELAY_CACHE_STALE_MS = 7 * 24 * 60 * 60 * 1000;
-
-type WritableTextSink = {
-  write(chunk: string): unknown;
-};
 
 type DoctorOutcome = 'pass' | 'degraded' | 'fail';
 

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -1,0 +1,150 @@
+import type { Command } from 'commander';
+
+import { type WritableTextSink, writeCliRaw, writeCliReport } from '../cli-output.js';
+import { ConfigStore } from '../config/store.js';
+import {
+  type ReadDockerComposeLogsOptions,
+  readDockerComposeLogs,
+} from '../runtime/docker-runtime.js';
+import { renderLoadConfigError, renderMissingConfigError } from './config.js';
+
+type LogsCommandOptions = {
+  readonly tail?: string;
+  readonly follow?: boolean;
+};
+
+export type LogsCommandDependencies = {
+  readonly store?: ConfigStore;
+  readonly checkedAt?: string;
+  readonly readLogs?: (
+    options: ReadDockerComposeLogsOptions,
+  ) => Promise<Awaited<ReturnType<typeof readDockerComposeLogs>>>;
+  readonly stdout?: WritableTextSink;
+  readonly stderr?: WritableTextSink;
+};
+
+export type LogsFlowResult =
+  | {
+      readonly ok: true;
+      readonly exitCode: 0;
+      readonly output: string;
+    }
+  | {
+      readonly ok: false;
+      readonly exitCode: 1;
+      readonly summary: string;
+    };
+
+export function registerLogsCommand(
+  program: Command,
+  dependencies: LogsCommandDependencies = {},
+): void {
+  program
+    .command('logs')
+    .description('Read the saved Docker Compose logs for the current runtime bundle.')
+    .option('--tail <lines>', 'Show this many log lines from the end of the bundle logs.')
+    .option('--follow', 'Keep streaming the Docker Compose logs until interrupted.')
+    .action(createLogsCommandAction(dependencies));
+}
+
+export function createLogsCommandAction(
+  dependencies: LogsCommandDependencies = {},
+): (options: LogsCommandOptions) => Promise<void> {
+  return async (options: LogsCommandOptions) => {
+    const result = await runLogsFlow(options, dependencies);
+    const stdout = dependencies.stdout ?? process.stdout;
+    const stderr = dependencies.stderr ?? process.stderr;
+
+    if (result.ok) {
+      writeCliRaw({ sink: stdout, text: result.output });
+    } else {
+      writeCliReport({ sink: stderr, text: result.summary, tone: 'error' });
+    }
+
+    process.exitCode = result.exitCode;
+  };
+}
+
+export async function runLogsFlow(
+  options: LogsCommandOptions,
+  dependencies: Omit<LogsCommandDependencies, 'stdout' | 'stderr'> = {},
+): Promise<LogsFlowResult> {
+  const store = dependencies.store ?? new ConfigStore();
+  const loadResult = await store.load();
+
+  if (!loadResult.ok) {
+    return {
+      ok: false,
+      exitCode: 1,
+      summary: renderLoadConfigError(loadResult),
+    };
+  }
+
+  if (loadResult.source === 'empty') {
+    return {
+      ok: false,
+      exitCode: 1,
+      summary: renderMissingConfigError(loadResult.message, store.paths.configFile),
+    };
+  }
+
+  const checkedAt = dependencies.checkedAt ?? new Date().toISOString();
+  let tail: number;
+
+  try {
+    tail = parsePositiveInteger(options.tail ?? '200', 'tail');
+  } catch (error) {
+    return {
+      ok: false,
+      exitCode: 1,
+      summary: [
+        'Mullgate runtime logs failed.',
+        'phase: input',
+        'source: cli',
+        `reason: ${error instanceof Error ? error.message : String(error)}`,
+      ].join('\n'),
+    };
+  }
+
+  const readLogs = dependencies.readLogs ?? readDockerComposeLogs;
+  const result = await readLogs({
+    composeFilePath: store.paths.runtimeComposeFile,
+    checkedAt,
+    tail,
+    follow: Boolean(options.follow),
+  });
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      exitCode: 1,
+      summary: [
+        'Mullgate runtime logs failed.',
+        `phase: ${result.phase}`,
+        `source: ${result.source}`,
+        `attempted at: ${result.checkedAt}`,
+        ...(result.code ? [`code: ${result.code}`] : []),
+        `docker compose: ${result.composeFilePath}`,
+        `command: ${result.command.rendered}`,
+        `reason: ${result.message}`,
+        ...(result.cause ? [`cause: ${result.cause}`] : []),
+      ].join('\n'),
+    };
+  }
+
+  return {
+    ok: true,
+    exitCode: 0,
+    output: result.stdout,
+  };
+}
+
+function parsePositiveInteger(raw: string, label: string): number {
+  const numeric = Number.parseInt(raw, 10);
+
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    throw new Error(`Expected --${label} to be a positive integer.`);
+  }
+
+  return numeric;
+}

--- a/src/commands/proxy.ts
+++ b/src/commands/proxy.ts
@@ -16,10 +16,13 @@ import {
   updateExposureConfig,
 } from './config.js';
 import { registerDoctorCommand } from './doctor.js';
+import { registerLogsCommand } from './logs.js';
 import { registerRecommendCommand } from './recommend.js';
 import { registerRelaysCommand } from './relays.js';
+import { registerRestartCommand } from './restart.js';
 import { registerStartCommand } from './start.js';
 import { registerStatusCommand } from './status.js';
+import { registerStopCommand } from './stop.js';
 
 export function registerProxyCommand(program: Command): void {
   const proxy = program
@@ -29,7 +32,10 @@ export function registerProxyCommand(program: Command): void {
     );
 
   registerStartCommand(proxy);
+  registerStopCommand(proxy);
+  registerRestartCommand(proxy);
   registerStatusCommand(proxy);
+  registerLogsCommand(proxy);
   registerDoctorCommand(proxy);
   registerValidateCommand(proxy);
   registerLocationsCommand(proxy, {
@@ -51,7 +57,10 @@ export function registerProxyCommand(program: Command): void {
       'Quick commands:',
       '  mullgate proxy access',
       '  mullgate proxy start',
+      '  mullgate proxy stop',
+      '  mullgate proxy restart',
       '  mullgate proxy status',
+      '  mullgate proxy logs --tail 50',
       '  mullgate proxy doctor',
       '  mullgate proxy export --regions',
       '',

--- a/src/commands/relays.ts
+++ b/src/commands/relays.ts
@@ -653,7 +653,7 @@ function renderRelayListReport(input: {
     `listed count: ${input.selectedRelays.length}`,
     ...(input.selectedRelays.length === 0
       ? ['relays: none']
-      : input.selectedRelays.map((relay, index) => renderRelayLine(relay, index))),
+      : ['relay table', ...renderRelayTable(input.selectedRelays)]),
   ].join('\n');
 }
 
@@ -717,10 +717,6 @@ function renderRelayVerifyReport(input: {
   ].join('\n');
 }
 
-function renderRelayLine(relay: MullvadRelay, index: number): string {
-  return `${index + 1}. ${renderRelaySummary(relay)} active=${relay.active ? 'yes' : 'no'} endpoint=${relay.endpointIpv4}`;
-}
-
 function renderRelaySummary(relay: MullvadRelay): string {
   return [
     relay.hostname,
@@ -731,6 +727,43 @@ function renderRelaySummary(relay: MullvadRelay): string {
     `run-mode=${relay.stboot ? 'ram' : 'disk'}`,
     `port-speed=${relay.networkPortSpeed ?? 'n/a'}`,
   ].join(' ');
+}
+
+function renderRelayTable(relays: readonly MullvadRelay[]): string[] {
+  const headers = [
+    '#',
+    'hostname',
+    'country',
+    'city',
+    'provider',
+    'owner',
+    'mode',
+    'speed',
+    'active',
+  ];
+  const rows = relays.map((relay, index) => [
+    String(index + 1),
+    relay.hostname,
+    relay.location.countryCode,
+    relay.location.cityCode,
+    relay.provider ?? 'n/a',
+    relay.owned ? 'mullvad' : 'rented',
+    relay.stboot ? 'ram' : 'disk',
+    relay.networkPortSpeed ? `${relay.networkPortSpeed}` : 'n/a',
+    relay.active ? 'yes' : 'no',
+  ]);
+  const widths = headers.map((header, columnIndex) =>
+    Math.max(header.length, ...rows.map((row) => row[columnIndex]?.length ?? 0)),
+  );
+
+  const formatRow = (row: readonly string[]) =>
+    row.map((value, index) => value.padEnd(widths[index] ?? value.length)).join('  ');
+
+  return [
+    formatRow(headers),
+    widths.map((width) => '-'.repeat(width)).join('  '),
+    ...rows.map(formatRow),
+  ];
 }
 
 function renderGlobalRelayFilterLabel(input: {

--- a/src/commands/restart.ts
+++ b/src/commands/restart.ts
@@ -1,0 +1,88 @@
+import type { Command } from 'commander';
+
+import { type WritableTextSink, writeCliReport } from '../cli-output.js';
+import { ConfigStore } from '../config/store.js';
+import { runStartFlow, type StartCommandDependencies } from './start.js';
+import { runStopFlow, type StopCommandDependencies } from './stop.js';
+
+export type RestartCommandDependencies = {
+  readonly store?: ConfigStore;
+  readonly checkedAt?: string;
+  readonly stdout?: WritableTextSink;
+  readonly stderr?: WritableTextSink;
+  readonly startDependencies?: Omit<
+    StartCommandDependencies,
+    'store' | 'checkedAt' | 'stdout' | 'stderr'
+  >;
+  readonly stopDependencies?: Omit<
+    StopCommandDependencies,
+    'store' | 'checkedAt' | 'stdout' | 'stderr'
+  >;
+};
+
+export function registerRestartCommand(
+  program: Command,
+  dependencies: RestartCommandDependencies = {},
+): void {
+  program
+    .command('restart')
+    .description('Stop the current runtime bundle, rerender artifacts, and start it again.')
+    .action(createRestartCommandAction(dependencies));
+}
+
+export function createRestartCommandAction(
+  dependencies: RestartCommandDependencies = {},
+): () => Promise<void> {
+  return async () => {
+    const stdout = dependencies.stdout ?? process.stdout;
+    const stderr = dependencies.stderr ?? process.stderr;
+    const checkedAt = dependencies.checkedAt ?? new Date().toISOString();
+    const store = dependencies.store ?? new ConfigStore();
+
+    const stopResult = await runStopFlow({
+      store,
+      checkedAt,
+      ...(dependencies.stopDependencies ?? {}),
+    });
+
+    if (!stopResult.ok) {
+      writeCliReport({ sink: stderr, text: stopResult.summary, tone: 'error' });
+      process.exitCode = stopResult.exitCode;
+      return;
+    }
+
+    const startResult = await runStartFlow({
+      store,
+      checkedAt,
+      ...(dependencies.startDependencies ?? {}),
+    });
+
+    const combinedSummary = [stopResult.summary, '', renderStartSummary(startResult)].join('\n');
+
+    if (startResult.ok) {
+      writeCliReport({ sink: stdout, text: combinedSummary, tone: 'success' });
+    } else {
+      writeCliReport({ sink: stderr, text: combinedSummary, tone: 'error' });
+    }
+
+    process.exitCode = startResult.exitCode;
+  };
+}
+
+function renderStartSummary(result: Awaited<ReturnType<typeof runStartFlow>>): string {
+  if (result.ok) {
+    return result.summary;
+  }
+
+  return [
+    'Mullgate restart failed during start.',
+    `phase: ${result.phase}`,
+    `source: ${result.source}`,
+    ...(result.attemptedAt ? [`attempted at: ${result.attemptedAt}`] : []),
+    ...(result.code ? [`code: ${result.code}`] : []),
+    ...(result.command ? [`command: ${result.command}`] : []),
+    `reason: ${result.message}`,
+    ...(result.cause ? [`cause: ${result.cause}`] : []),
+    `config: ${result.paths.configFile}`,
+  ].join('\n');
+}

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -9,10 +9,11 @@ import {
   verifyHttpsAssets,
   withRuntimeStatus,
 } from '../app/setup-runner.js';
-import { writeCliReport } from '../cli-output.js';
+import { type WritableTextSink, writeCliReport } from '../cli-output.js';
 import type { MullgatePaths } from '../config/paths.js';
 import type { MullgateConfig, RuntimeStartDiagnostic } from '../config/schema.js';
 import { ConfigStore } from '../config/store.js';
+import { fetchRelays, type MullvadRelayCatalog } from '../mullvad/fetch-relays.js';
 import {
   type DockerRuntimeResult,
   type StartDockerRuntimeOptions,
@@ -33,10 +34,7 @@ import {
 } from '../runtime/validate-runtime.js';
 
 type ValidationSourceSummary = string;
-
-type WritableTextSink = {
-  write(chunk: string): unknown;
-};
+const RELAY_CACHE_REFRESH_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 type RouteDiagnosticContext = {
   readonly routeId?: string | null;
@@ -73,7 +71,7 @@ export type StartSuccess = {
   readonly exitCode: 0;
   readonly paths: MullgatePaths;
   readonly config: MullgateConfig;
-  readonly report: RuntimeStartDiagnostic;
+  readonly report?: RuntimeStartDiagnostic;
   readonly validationSource: ValidationSourceSummary;
   readonly composeFilePath: string;
   readonly manifestPath: string;
@@ -118,6 +116,7 @@ export type StartFlowResult = StartSuccess | StartFailure;
 export type StartCommandDependencies = {
   readonly store?: ConfigStore;
   readonly checkedAt?: string;
+  readonly dryRun?: boolean;
   readonly startRuntime?: (options: StartDockerRuntimeOptions) => Promise<DockerRuntimeResult>;
   readonly validateOptions?: Pick<
     ValidateRuntimeOptions,
@@ -136,14 +135,18 @@ export function registerStartCommand(
     .description(
       'Re-render derived runtime artifacts from saved config, validate them, and launch the Docker runtime bundle.',
     )
+    .option('--dry-run', 'Render and validate artifacts without launching Docker.')
     .action(createStartCommandAction(dependencies));
 }
 
 export function createStartCommandAction(
   dependencies: StartCommandDependencies = {},
-): () => Promise<void> {
-  return async () => {
-    const result = await runStartFlow(dependencies);
+): (options?: { dryRun?: boolean }) => Promise<void> {
+  return async (options?: { dryRun?: boolean }) => {
+    const result = await runStartFlow({
+      ...dependencies,
+      dryRun: Boolean(options?.dryRun || dependencies.dryRun),
+    });
     writeStartResult(result, dependencies);
     process.exitCode = result.exitCode;
   };
@@ -219,9 +222,15 @@ export async function runStartFlow(
     });
   }
 
+  const effectiveRelayCatalog = await refreshRelayCatalogIfStale(
+    store.paths.provisioningCacheFile,
+    relayCatalog.value,
+    attemptedAt,
+  );
+
   const runtimeProxyRender = await renderRuntimeProxyArtifacts({
     config: baseConfig,
-    relayCatalog: relayCatalog.value,
+    relayCatalog: effectiveRelayCatalog,
     paths: store.paths,
     generatedAt: attemptedAt,
   });
@@ -294,6 +303,51 @@ export async function runStartFlow(
       routeBindIp: validationResult.routeBindIp,
       serviceName: validationResult.serviceName,
     });
+  }
+
+  if (dependencies.dryRun) {
+    const validatedConfig = withRuntimeStatus(
+      baseConfig,
+      'validated',
+      attemptedAt,
+      `Validated shared entry tunnel plus ${baseConfig.routing.locations.length} configured routes via ${validationResult.validationSource}; Docker launch skipped because --dry-run was used.`,
+    );
+    const persisted = await persistConfigOnly(store, validatedConfig);
+
+    if (!persisted.ok) {
+      return persisted;
+    }
+
+    return {
+      ok: true,
+      phase: 'compose-launch',
+      source: 'docker-compose',
+      exitCode: 0,
+      paths: store.paths,
+      config: validatedConfig,
+      validationSource: validationResult.validationSource,
+      composeFilePath: runtimeBundle.artifactPaths.dockerComposePath,
+      manifestPath: runtimeBundle.artifactPaths.manifestPath,
+      validationReportPath: validationResult.reportPath,
+      summary: [
+        'Mullgate runtime dry-run complete.',
+        'phase: validation',
+        'source: saved-config',
+        `attempted at: ${attemptedAt}`,
+        `routes: ${baseConfig.routing.locations.length}`,
+        `access mode: ${baseConfig.setup.access.mode}`,
+        `config: ${store.paths.configFile}`,
+        `entry wireproxy config: ${runtimeProxyRender.artifactPaths.entryWireproxyConfigPath}`,
+        `route proxy config: ${runtimeProxyRender.artifactPaths.routeProxyConfigPath}`,
+        `relay cache: ${runtimeProxyRender.artifactPaths.relayCachePath}`,
+        `docker compose: ${runtimeBundle.artifactPaths.dockerComposePath}`,
+        `runtime manifest: ${runtimeBundle.artifactPaths.manifestPath}`,
+        `validation report: ${validationResult.reportPath}`,
+        `validation: ${validationResult.validationSource}`,
+        'docker launch: skipped (--dry-run)',
+        'runtime status: validated',
+      ].join('\n'),
+    };
   }
 
   const startingConfig = withRuntimeStatus(
@@ -474,6 +528,34 @@ function redactInlineSelectorUrl(url: string): string {
   return url.replace(/:\/\/([^:@]+):@/, '://$1:[redacted]@');
 }
 
+async function refreshRelayCatalogIfStale(
+  relayCachePath: string,
+  relayCatalog: MullvadRelayCatalog,
+  checkedAt: string,
+): Promise<MullvadRelayCatalog> {
+  const fetchedAt = Date.parse(relayCatalog.fetchedAt);
+
+  if (
+    !Number.isFinite(fetchedAt) ||
+    Date.parse(checkedAt) - fetchedAt <= RELAY_CACHE_REFRESH_TTL_MS
+  ) {
+    return relayCatalog;
+  }
+
+  const refreshed = await fetchRelays({ fetchedAt: checkedAt });
+
+  if (!refreshed.ok) {
+    return relayCatalog;
+  }
+
+  await mkdir(path.dirname(relayCachePath), { recursive: true, mode: 0o700 });
+  await writeFile(relayCachePath, `${JSON.stringify(refreshed.value, null, 2)}\n`, {
+    mode: 0o600,
+  });
+
+  return refreshed.value;
+}
+
 function writeStartResult(
   result: StartFlowResult,
   dependencies: Pick<StartCommandDependencies, 'stdout' | 'stderr'>,
@@ -501,6 +583,11 @@ function writeStartResult(
     ...(result.command ? [`command: ${result.command}`] : []),
     `reason: ${result.message}`,
     ...(result.cause ? [`cause: ${result.cause}`] : []),
+    ...(result.phase === 'compose-launch' && result.code === 'COMPOSE_UP_FAILED'
+      ? [
+          'remediation: Inspect `docker compose ps` / `docker compose logs`, fix the failing entry tunnel, route proxy, or routing layer, then rerun `mullgate proxy start`.',
+        ]
+      : []),
     `config: ${result.paths.configFile}`,
     ...(result.validationSource ? [`validation: ${result.validationSource}`] : []),
     ...(result.report ? [`start report: ${result.paths.runtimeStartDiagnosticsFile}`] : []),

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,6 +1,6 @@
 import type { Command } from 'commander';
 
-import { writeCliReport } from '../cli-output.js';
+import { type WritableTextSink, writeCliReport } from '../cli-output.js';
 import {
   buildExposureContract,
   computePublishedPort,
@@ -31,10 +31,6 @@ import {
 } from './runtime-diagnostics.js';
 
 const ROUTING_LAYER_SERVICE = 'routing-layer';
-
-type WritableTextSink = {
-  write(chunk: string): unknown;
-};
 
 type StatusPhase = 'unconfigured' | 'stopped' | 'starting' | 'running' | 'degraded' | 'error';
 

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -1,0 +1,127 @@
+import type { Command } from 'commander';
+
+import { withRuntimeStatus } from '../app/setup-runner.js';
+import { type WritableTextSink, writeCliReport } from '../cli-output.js';
+import { ConfigStore } from '../config/store.js';
+import { type StopDockerRuntimeOptions, stopDockerRuntime } from '../runtime/docker-runtime.js';
+import { renderLoadConfigError, renderMissingConfigError } from './config.js';
+
+export type StopCommandDependencies = {
+  readonly store?: ConfigStore;
+  readonly checkedAt?: string;
+  readonly stopRuntime?: (
+    options: StopDockerRuntimeOptions,
+  ) => Promise<Awaited<ReturnType<typeof stopDockerRuntime>>>;
+  readonly stdout?: WritableTextSink;
+  readonly stderr?: WritableTextSink;
+};
+
+export type StopFlowResult =
+  | {
+      readonly ok: true;
+      readonly exitCode: 0;
+      readonly summary: string;
+    }
+  | {
+      readonly ok: false;
+      readonly exitCode: 1;
+      readonly summary: string;
+    };
+
+export function registerStopCommand(
+  program: Command,
+  dependencies: StopCommandDependencies = {},
+): void {
+  program
+    .command('stop')
+    .description('Stop the saved Docker runtime bundle without rerendering config artifacts.')
+    .action(createStopCommandAction(dependencies));
+}
+
+export function createStopCommandAction(
+  dependencies: StopCommandDependencies = {},
+): () => Promise<void> {
+  return async () => {
+    const result = await runStopFlow(dependencies);
+    const stdout = dependencies.stdout ?? process.stdout;
+    const stderr = dependencies.stderr ?? process.stderr;
+
+    if (result.ok) {
+      writeCliReport({ sink: stdout, text: result.summary, tone: 'success' });
+    } else {
+      writeCliReport({ sink: stderr, text: result.summary, tone: 'error' });
+    }
+
+    process.exitCode = result.exitCode;
+  };
+}
+
+export async function runStopFlow(
+  dependencies: Omit<StopCommandDependencies, 'stdout' | 'stderr'> = {},
+): Promise<StopFlowResult> {
+  const store = dependencies.store ?? new ConfigStore();
+  const loadResult = await store.load();
+
+  if (!loadResult.ok) {
+    return {
+      ok: false,
+      exitCode: 1,
+      summary: renderLoadConfigError(loadResult),
+    };
+  }
+
+  if (loadResult.source === 'empty') {
+    return {
+      ok: false,
+      exitCode: 1,
+      summary: renderMissingConfigError(loadResult.message, store.paths.configFile),
+    };
+  }
+
+  const checkedAt = dependencies.checkedAt ?? new Date().toISOString();
+  const stopRuntime = dependencies.stopRuntime ?? stopDockerRuntime;
+  const composeFilePath = store.paths.runtimeComposeFile;
+  const stopResult = await stopRuntime({ composeFilePath, checkedAt });
+
+  if (!stopResult.ok) {
+    return {
+      ok: false,
+      exitCode: 1,
+      summary: [
+        'Mullgate runtime stop failed.',
+        `phase: ${stopResult.phase}`,
+        `source: ${stopResult.source}`,
+        `attempted at: ${stopResult.checkedAt}`,
+        ...(stopResult.code ? [`code: ${stopResult.code}`] : []),
+        `docker compose: ${stopResult.composeFilePath}`,
+        `command: ${stopResult.command.rendered}`,
+        `reason: ${stopResult.message}`,
+        ...(stopResult.cause ? [`cause: ${stopResult.cause}`] : []),
+        'remediation: Check `docker compose ps` / `docker compose logs` for the saved runtime bundle, resolve the failing service or Docker issue, then rerun `mullgate proxy stop`.',
+      ].join('\n'),
+    };
+  }
+
+  const stoppedConfig = withRuntimeStatus(
+    loadResult.config,
+    'validated',
+    checkedAt,
+    `Runtime stopped via docker compose down from ${composeFilePath}.`,
+  );
+  await store.save(stoppedConfig);
+
+  return {
+    ok: true,
+    exitCode: 0,
+    summary: [
+      'Mullgate runtime stopped.',
+      'phase: compose-down',
+      'source: docker-compose',
+      `attempted at: ${checkedAt}`,
+      `docker compose: ${composeFilePath}`,
+      `command: ${stopResult.command.rendered}`,
+      `config: ${store.paths.configFile}`,
+      'runtime status: validated (bundle stopped)',
+    ].join('\n'),
+  };
+}

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,0 +1,36 @@
+import os from 'node:os';
+
+import type { Command } from 'commander';
+
+import packageJson from '../../package.json' with { type: 'json' };
+import { type WritableTextSink, writeCliReport } from '../cli-output.js';
+import { CONFIG_VERSION } from '../config/schema.js';
+
+export type VersionCommandDependencies = {
+  readonly stdout?: WritableTextSink;
+};
+
+export function registerVersionCommand(
+  program: Command,
+  dependencies: VersionCommandDependencies = {},
+): void {
+  program
+    .command('version')
+    .description('Print the CLI version plus core runtime metadata for support reports.')
+    .action(() => {
+      const stdout = dependencies.stdout ?? process.stdout;
+
+      writeCliReport({
+        sink: stdout,
+        text: [
+          'Mullgate version',
+          `cli version: ${packageJson.version}`,
+          `config schema: ${CONFIG_VERSION}`,
+          `node: ${process.version}`,
+          `platform: ${process.platform}`,
+          `arch: ${process.arch}`,
+          `hostname: ${os.hostname()}`,
+        ].join('\n'),
+      });
+    });
+}

--- a/src/runtime/docker-runtime.ts
+++ b/src/runtime/docker-runtime.ts
@@ -119,6 +119,82 @@ export type DockerComposeStatusFailure = {
 
 export type DockerComposeStatusResult = DockerComposeStatusSuccess | DockerComposeStatusFailure;
 
+export type StopDockerRuntimeOptions = {
+  readonly composeFilePath: string;
+  readonly checkedAt?: string;
+  readonly cwd?: string;
+  readonly dockerBinary?: string;
+  readonly runner?: ProcessRunner;
+};
+
+export type StopDockerRuntimeSuccess = {
+  ok: true;
+  phase: 'compose-down';
+  source: 'docker-compose';
+  checkedAt: string;
+  composeFilePath: string;
+  command: DockerCommandMetadata;
+  message: string;
+  stdout: string;
+  stderr: string;
+};
+
+export type StopDockerRuntimeFailure = {
+  ok: false;
+  phase: 'compose-detect' | 'compose-down';
+  source: 'docker-binary' | 'docker-compose';
+  checkedAt: string;
+  code: 'DOCKER_COMPOSE_MISSING' | 'COMPOSE_DOWN_FAILED';
+  composeFilePath: string;
+  command: DockerCommandMetadata;
+  message: string;
+  cause?: string;
+  artifactPath?: string;
+  exitCode?: number | null;
+};
+
+export type StopDockerRuntimeResult = StopDockerRuntimeSuccess | StopDockerRuntimeFailure;
+
+export type ReadDockerComposeLogsOptions = {
+  readonly composeFilePath: string;
+  readonly checkedAt?: string;
+  readonly cwd?: string;
+  readonly dockerBinary?: string;
+  readonly runner?: ProcessRunner;
+  readonly tail?: number;
+  readonly follow?: boolean;
+};
+
+export type ReadDockerComposeLogsSuccess = {
+  ok: true;
+  phase: 'compose-logs';
+  source: 'docker-compose';
+  checkedAt: string;
+  composeFilePath: string;
+  command: DockerCommandMetadata;
+  message: string;
+  stdout: string;
+  stderr: string;
+};
+
+export type ReadDockerComposeLogsFailure = {
+  ok: false;
+  phase: 'compose-detect' | 'compose-logs';
+  source: 'docker-binary' | 'docker-compose';
+  checkedAt: string;
+  code: 'DOCKER_COMPOSE_MISSING' | 'COMPOSE_LOGS_FAILED';
+  composeFilePath: string;
+  command: DockerCommandMetadata;
+  message: string;
+  cause?: string;
+  artifactPath?: string;
+  exitCode?: number | null;
+};
+
+export type ReadDockerComposeLogsResult =
+  | ReadDockerComposeLogsSuccess
+  | ReadDockerComposeLogsFailure;
+
 export type StartDockerRuntimeOptions = {
   readonly composeFilePath: string;
   readonly checkedAt?: string;
@@ -236,6 +312,166 @@ export async function startDockerRuntime(
     message: 'Docker Compose launched the Mullgate runtime bundle in detached mode.',
     stdout: launchResult.stdout,
     stderr: launchResult.stderr,
+  };
+}
+
+export async function stopDockerRuntime(
+  options: StopDockerRuntimeOptions,
+): Promise<StopDockerRuntimeResult> {
+  const checkedAt = options.checkedAt ?? new Date().toISOString();
+  const dockerBinary = options.dockerBinary ?? DEFAULT_DOCKER_BINARY;
+  const cwd = options.cwd ?? path.dirname(options.composeFilePath);
+  const runner = options.runner ?? defaultProcessRunner;
+
+  const detectFailure = await detectDockerCompose({
+    composeFilePath: options.composeFilePath,
+    checkedAt,
+    dockerBinary,
+    cwd,
+    runner,
+    missingBinaryMessage:
+      'Docker CLI is not installed or is not on PATH, so Mullgate cannot stop the runtime bundle.',
+    detectFailureMessage:
+      'Docker is installed but `docker compose` is unavailable, so Mullgate cannot stop the runtime bundle.',
+  });
+
+  if (detectFailure) {
+    return detectFailure;
+  }
+
+  const stopCommand = buildCommand(
+    dockerBinary,
+    ['compose', '--file', options.composeFilePath, 'down', '--remove-orphans'],
+    cwd,
+  );
+  const stopResult = await runner(stopCommand.binary, stopCommand.args, { cwd: stopCommand.cwd });
+
+  if (stopResult.error?.code === 'ENOENT') {
+    return {
+      ok: false,
+      phase: 'compose-down',
+      source: 'docker-binary',
+      checkedAt,
+      code: 'DOCKER_COMPOSE_MISSING',
+      composeFilePath: options.composeFilePath,
+      command: stopCommand,
+      message: 'Docker disappeared before Mullgate could stop the runtime bundle.',
+      cause: stopResult.error.message,
+      artifactPath: options.composeFilePath,
+    };
+  }
+
+  if ((stopResult.exitCode ?? 1) !== 0) {
+    return {
+      ok: false,
+      phase: 'compose-down',
+      source: 'docker-compose',
+      checkedAt,
+      code: 'COMPOSE_DOWN_FAILED',
+      composeFilePath: options.composeFilePath,
+      command: stopCommand,
+      message: 'Docker Compose failed while stopping the Mullgate runtime bundle.',
+      cause: summarizeProcessFailure(stopResult, 'docker compose down --remove-orphans failed.'),
+      artifactPath: options.composeFilePath,
+      exitCode: stopResult.exitCode,
+    };
+  }
+
+  return {
+    ok: true,
+    phase: 'compose-down',
+    source: 'docker-compose',
+    checkedAt,
+    composeFilePath: options.composeFilePath,
+    command: stopCommand,
+    message: 'Docker Compose stopped the Mullgate runtime bundle.',
+    stdout: stopResult.stdout,
+    stderr: stopResult.stderr,
+  };
+}
+
+export async function readDockerComposeLogs(
+  options: ReadDockerComposeLogsOptions,
+): Promise<ReadDockerComposeLogsResult> {
+  const checkedAt = options.checkedAt ?? new Date().toISOString();
+  const dockerBinary = options.dockerBinary ?? DEFAULT_DOCKER_BINARY;
+  const cwd = options.cwd ?? path.dirname(options.composeFilePath);
+  const runner = options.runner ?? defaultProcessRunner;
+  const tail = Math.max(1, options.tail ?? 200);
+
+  const detectFailure = await detectDockerCompose({
+    composeFilePath: options.composeFilePath,
+    checkedAt,
+    dockerBinary,
+    cwd,
+    runner,
+    missingBinaryMessage:
+      'Docker CLI is not installed or is not on PATH, so Mullgate cannot read runtime logs.',
+    detectFailureMessage:
+      'Docker is installed but `docker compose` is unavailable, so Mullgate cannot read runtime logs.',
+  });
+
+  if (detectFailure) {
+    return detectFailure;
+  }
+
+  const logCommand = buildCommand(
+    dockerBinary,
+    [
+      'compose',
+      '--file',
+      options.composeFilePath,
+      'logs',
+      '--no-color',
+      '--tail',
+      String(tail),
+      ...(options.follow ? ['--follow'] : []),
+    ],
+    cwd,
+  );
+  const logResult = await runner(logCommand.binary, logCommand.args, { cwd: logCommand.cwd });
+
+  if (logResult.error?.code === 'ENOENT') {
+    return {
+      ok: false,
+      phase: 'compose-logs',
+      source: 'docker-binary',
+      checkedAt,
+      code: 'DOCKER_COMPOSE_MISSING',
+      composeFilePath: options.composeFilePath,
+      command: logCommand,
+      message: 'Docker disappeared before Mullgate could read the runtime logs.',
+      cause: logResult.error.message,
+      artifactPath: options.composeFilePath,
+    };
+  }
+
+  if ((logResult.exitCode ?? 1) !== 0) {
+    return {
+      ok: false,
+      phase: 'compose-logs',
+      source: 'docker-compose',
+      checkedAt,
+      code: 'COMPOSE_LOGS_FAILED',
+      composeFilePath: options.composeFilePath,
+      command: logCommand,
+      message: 'Docker Compose failed while reading the Mullgate runtime logs.',
+      cause: summarizeProcessFailure(logResult, 'docker compose logs failed.'),
+      artifactPath: options.composeFilePath,
+      exitCode: logResult.exitCode,
+    };
+  }
+
+  return {
+    ok: true,
+    phase: 'compose-logs',
+    source: 'docker-compose',
+    checkedAt,
+    composeFilePath: options.composeFilePath,
+    command: logCommand,
+    message: 'Docker Compose returned the requested Mullgate runtime logs.',
+    stdout: logResult.stdout,
+    stderr: logResult.stderr,
   };
 }
 

--- a/test/cli/help-command.test.ts
+++ b/test/cli/help-command.test.ts
@@ -63,6 +63,9 @@ describe('mullgate help command contract', () => {
       setupHelp,
       proxyHelp,
       proxyStartHelp,
+      proxyStopHelp,
+      proxyRestartHelp,
+      proxyLogsHelp,
       proxyStatusHelp,
       proxyDoctorHelp,
       proxyAccessHelp,
@@ -72,11 +75,16 @@ describe('mullgate help command contract', () => {
       proxyAutostartHelp,
       proxyValidateHelp,
       configHelp,
+      versionHelp,
+      completionsHelp,
     ] = await Promise.all([
       expectHelpOutput(['--help']),
       expectHelpOutput(['setup', '--help']),
       expectHelpOutput(['proxy', '--help']),
       expectHelpOutput(['proxy', 'start', '--help']),
+      expectHelpOutput(['proxy', 'stop', '--help']),
+      expectHelpOutput(['proxy', 'restart', '--help']),
+      expectHelpOutput(['proxy', 'logs', '--help']),
       expectHelpOutput(['proxy', 'status', '--help']),
       expectHelpOutput(['proxy', 'doctor', '--help']),
       expectHelpOutput(['proxy', 'access', '--help']),
@@ -86,6 +94,8 @@ describe('mullgate help command contract', () => {
       expectHelpOutput(['proxy', 'autostart', '--help']),
       expectHelpOutput(['proxy', 'validate', '--help']),
       expectHelpOutput(['config', '--help']),
+      expectHelpOutput(['version', '--help']),
+      expectHelpOutput(['completions', '--help']),
     ]);
 
     expect(`\n${topLevelHelp}`).toMatchInlineSnapshot(`
@@ -95,16 +105,20 @@ describe('mullgate help command contract', () => {
       Minimal Mullvad proxy CLI for setup, daily proxy operations, and advanced config
 
       Options:
-        -h, --help       display help for command
+        -v, --version        display the installed Mullgate CLI version
+        -h, --help           display help for command
 
       Commands:
-        setup [options]  Run the guided Mullvad-backed setup flow and persist config
-                         plus derived runtime artifacts.
-        proxy            Operate runtime, access, export, relay, and startup surfaces
-                         for routed proxies.
-        config           Inspect saved config values, raw paths, and advanced config
-                         fields.
-        help [command]   display help for command"
+        setup [options]      Run the guided Mullvad-backed setup flow and persist
+                             config plus derived runtime artifacts.
+        proxy                Operate runtime, access, export, relay, and startup
+                             surfaces for routed proxies.
+        config               Inspect saved config values, raw paths, and advanced
+                             config fields.
+        version              Print the CLI version plus core runtime metadata for
+                             support reports.
+        completions <shell>  Generate shell completion scripts for bash, zsh, or fish.
+        help [command]       display help for command"
     `);
     expect(`\n${setupHelp}`).toMatchInlineSnapshot(`
       "
@@ -164,10 +178,16 @@ describe('mullgate help command contract', () => {
         -h, --help          display help for command
 
       Commands:
-        start               Re-render derived runtime artifacts from saved config,
+        start [options]     Re-render derived runtime artifacts from saved config,
                             validate them, and launch the Docker runtime bundle.
+        stop                Stop the saved Docker runtime bundle without rerendering
+                            config artifacts.
+        restart             Stop the current runtime bundle, rerender artifacts, and
+                            start it again.
         status              Inspect saved Mullgate state, runtime artifacts, and live
                             Docker Compose status in one report.
+        logs [options]      Read the saved Docker Compose logs for the current runtime
+                            bundle.
         doctor              Run deterministic, route-aware diagnostics for config,
                             runtime, bind, DNS, and last-start failures.
         validate [options]  Validate the saved or freshly rendered shared runtime
@@ -188,7 +208,10 @@ describe('mullgate help command contract', () => {
       Quick commands:
         mullgate proxy access
         mullgate proxy start
+        mullgate proxy stop
+        mullgate proxy restart
         mullgate proxy status
+        mullgate proxy logs --tail 50
         mullgate proxy doctor
         mullgate proxy export --regions
 
@@ -207,7 +230,37 @@ describe('mullgate help command contract', () => {
       the Docker runtime bundle.
 
       Options:
+        --dry-run   Render and validate artifacts without launching Docker.
         -h, --help  display help for command"
+    `);
+    expect(`\n${proxyStopHelp}`).toMatchInlineSnapshot(`
+      "
+      Usage: mullgate proxy stop [options]
+
+      Stop the saved Docker runtime bundle without rerendering config artifacts.
+
+      Options:
+        -h, --help  display help for command"
+    `);
+    expect(`\n${proxyRestartHelp}`).toMatchInlineSnapshot(`
+      "
+      Usage: mullgate proxy restart [options]
+
+      Stop the current runtime bundle, rerender artifacts, and start it again.
+
+      Options:
+        -h, --help  display help for command"
+    `);
+    expect(`\n${proxyLogsHelp}`).toMatchInlineSnapshot(`
+      "
+      Usage: mullgate proxy logs [options]
+
+      Read the saved Docker Compose logs for the current runtime bundle.
+
+      Options:
+        --tail <lines>  Show this many log lines from the end of the bundle logs.
+        --follow        Keep streaming the Docker Compose logs until interrupted.
+        -h, --help      display help for command"
     `);
     expect(`\n${proxyStatusHelp}`).toMatchInlineSnapshot(`
       "
@@ -385,6 +438,27 @@ describe('mullgate help command contract', () => {
         set [options] <keyPath> [value]  Update a saved config value without editing
                                          JSON by hand.
         help [command]                   display help for command"
+    `);
+    expect(`\n${versionHelp}`).toMatchInlineSnapshot(`
+      "
+      Usage: mullgate version [options]
+
+      Print the CLI version plus core runtime metadata for support reports.
+
+      Options:
+        -h, --help  display help for command"
+    `);
+    expect(`\n${completionsHelp}`).toMatchInlineSnapshot(`
+      "
+      Usage: mullgate completions [options] <shell>
+
+      Generate shell completion scripts for bash, zsh, or fish.
+
+      Arguments:
+        shell       Target shell: bash, zsh, or fish.
+
+      Options:
+        -h, --help  display help for command"
     `);
   });
 });

--- a/test/cli/misc-command.test.ts
+++ b/test/cli/misc-command.test.ts
@@ -1,0 +1,74 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+type CliResult = {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+};
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..');
+const tsxCliPath = path.join(repoRoot, 'node_modules/tsx/dist/cli.mjs');
+
+async function runCli(args: readonly string[]): Promise<CliResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [tsxCliPath, 'src/cli.ts', ...args], {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: 'pipe',
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+
+    child.stdout.on('data', (chunk) => stdoutChunks.push(Buffer.from(chunk)));
+    child.stderr.on('data', (chunk) => stderrChunks.push(Buffer.from(chunk)));
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({
+        status: code,
+        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf8'),
+      });
+    });
+  });
+}
+
+describe('mullgate misc command contract', () => {
+  it('prints structured version details', { timeout: 15000 }, async () => {
+    const result = await runCli(['version']);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const normalized = result.stdout
+      .trimEnd()
+      .replace(/hostname: .+/u, 'hostname: HOSTNAME_REPLACED');
+    expect(`\n${normalized}`).toMatchInlineSnapshot(`
+      "
+      Mullgate version
+      cli version: 1.3.0
+      config schema: 2
+      node: ${process.version}
+      platform: ${process.platform}
+      arch: ${process.arch}
+      hostname: HOSTNAME_REPLACED"
+    `);
+  });
+
+  it('prints bash completions', { timeout: 15000 }, async () => {
+    const result = await runCli(['completions', 'bash']);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('_mullgate_complete()');
+    expect(result.stdout).toContain('complete -F _mullgate_complete mullgate');
+    expect(result.stdout).toContain(
+      'proxy_subcommands="start stop restart status logs doctor validate list export autostart access relay"',
+    );
+    expect(result.stdout).toContain(
+      'config_subcommands="path show get set validate regions hosts"',
+    );
+  });
+});

--- a/test/cli/relays-and-recommend-command.test.ts
+++ b/test/cli/relays-and-recommend-command.test.ts
@@ -307,8 +307,11 @@ describe('relay and recommend flows', () => {
       inactive relays: active only
       matched count: 2
       listed count: 2
-      1. se-got-wg-101 country=se city=got provider=m247 owner=mullvad run-mode=ram port-speed=10000 active=yes endpoint=185.213.154.2
-      2. se-sto-wg-002 country=se city=sto provider=m247 owner=mullvad run-mode=ram port-speed=10000 active=yes endpoint=185.213.154.22"
+      relay table
+      #  hostname       country  city  provider  owner    mode  speed  active
+      -  -------------  -------  ----  --------  -------  ----  -----  ------
+      1  se-got-wg-101  se       got   m247      mullvad  ram   10000  yes   
+      2  se-sto-wg-002  se       sto   m247      mullvad  ram   10000  yes   "
     `);
   });
 

--- a/test/cli/start-command.test.ts
+++ b/test/cli/start-command.test.ts
@@ -519,6 +519,68 @@ describe('mullgate start command', () => {
     ]);
   });
 
+  it('supports a dry-run that validates artifacts without launching Docker', async () => {
+    const env = createTempEnvironment();
+    const store = await seedSavedConfig(env);
+    const stdout = createBufferSink();
+    const stderr = createBufferSink();
+    const wireproxyBinary = await createFakeWireproxyBinary(
+      requireDefined(env.HOME, 'Expected HOME in the test env.'),
+    );
+    let launchCount = 0;
+
+    const action = createStartCommandAction({
+      store,
+      checkedAt: '2026-03-21T01:03:00.000Z',
+      stdout,
+      stderr,
+      validateOptions: {
+        wireproxyBinary,
+      },
+      startRuntime: async () => {
+        launchCount += 1;
+        throw new Error('dry-run should not launch Docker');
+      },
+    });
+
+    await action({ dryRun: true });
+
+    expect(launchCount).toBe(0);
+    expect(process.exitCode).toBe(0);
+    expect(stderr.value.current).toBe('');
+
+    const loadResult = await store.load();
+    expect(loadResult.ok && loadResult.source === 'file').toBe(true);
+
+    if (!loadResult.ok || loadResult.source !== 'file') {
+      return;
+    }
+
+    expect(loadResult.config.runtime.status).toMatchObject({
+      phase: 'validated',
+      lastCheckedAt: '2026-03-21T01:03:00.000Z',
+    });
+    expect(`\n${normalizeOutput(stdout.value.current, env)}`).toMatchInlineSnapshot(`
+      "
+      Mullgate runtime dry-run complete.
+      phase: validation
+      source: saved-config
+      attempted at: 2026-03-21T01:03:00.000Z
+      routes: 2
+      access mode: published-routes
+      config: /tmp/mullgate-home/config/mullgate/config.json
+      entry wireproxy config: /tmp/mullgate-home/state/mullgate/runtime/entry-wireproxy.conf
+      route proxy config: /tmp/mullgate-home/state/mullgate/runtime/route-proxy.cfg
+      relay cache: /tmp/mullgate-home/cache/mullgate/relays.json
+      docker compose: /tmp/mullgate-home/state/mullgate/runtime/docker-compose.yml
+      runtime manifest: /tmp/mullgate-home/state/mullgate/runtime/runtime-manifest.json
+      validation report: /tmp/mullgate-home/state/mullgate/runtime/runtime-validation.json
+      validation: wireproxy-binary/configtest + docker/3proxy-startup
+      docker launch: skipped (--dry-run)
+      runtime status: validated"
+    `);
+  });
+
   it(
     'persists secret-safe route-aware compose failure diagnostics with phase, source, code, and validation metadata',
     { timeout: 15000 },
@@ -614,6 +676,7 @@ describe('mullgate start command', () => {
       command: docker compose --file /tmp/mullgate-home/state/mullgate/runtime/docker-compose.yml up --detach --force-recreate
       reason: Docker Compose failed to start the Mullgate runtime bundle.
       cause: service route-proxy crashed while booting at-vie-wg-001 for proxy-password / 123456789012 / private-key-value-2 while reading -----BEGIN PRIVATE KEY-----/nfixture/n-----END PRIVATE KEY-----
+      remediation: Inspect \`docker compose ps\` / \`docker compose logs\`, fix the failing entry tunnel, route proxy, or routing layer, then rerun \`mullgate proxy start\`.
       config: /tmp/mullgate-home/config/mullgate/config.json
       validation: wireproxy-binary/configtest + docker/3proxy-startup
       start report: /tmp/mullgate-home/state/mullgate/runtime/last-start.json

--- a/test/e2e/full-runtime.test.ts
+++ b/test/e2e/full-runtime.test.ts
@@ -1,0 +1,111 @@
+import { spawn } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..');
+const tsxCliPath = path.join(repoRoot, 'node_modules/tsx/dist/cli.mjs');
+const temporaryDirectories: string[] = [];
+
+type CliResult = {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+};
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+
+  if (!value) {
+    throw new Error(`Missing required ${name} for Mullgate E2E.`);
+  }
+
+  return value;
+}
+
+async function runCli(args: readonly string[], env: NodeJS.ProcessEnv): Promise<CliResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [tsxCliPath, 'src/cli.ts', ...args], {
+      cwd: repoRoot,
+      env,
+      stdio: 'pipe',
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+
+    child.stdout.on('data', (chunk) => stdoutChunks.push(Buffer.from(chunk)));
+    child.stderr.on('data', (chunk) => stderrChunks.push(Buffer.from(chunk)));
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({
+        status: code,
+        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf8'),
+      });
+    });
+  });
+}
+
+afterAll(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe.skipIf(process.env.MULLGATE_E2E !== '1')('mullgate e2e runtime flow', () => {
+  it(
+    'runs setup, start, status, doctor, and stop against a real Docker-backed environment',
+    { timeout: 180000 },
+    async () => {
+      const root = mkdtempSync(path.join(tmpdir(), 'mullgate-e2e-'));
+      const home = root.replaceAll('\\', '/');
+      temporaryDirectories.push(root);
+
+      const env = {
+        ...process.env,
+        MULLGATE_PLATFORM: 'linux',
+        HOME: home,
+        XDG_CONFIG_HOME: `${home}/config`,
+        XDG_STATE_HOME: `${home}/state`,
+        XDG_CACHE_HOME: `${home}/cache`,
+      };
+
+      const setupResult = await runCli(
+        [
+          'setup',
+          '--non-interactive',
+          '--account-number',
+          requiredEnv('MULLGATE_E2E_ACCOUNT_NUMBER'),
+          '--username',
+          requiredEnv('MULLGATE_E2E_PROXY_USERNAME'),
+          '--password',
+          requiredEnv('MULLGATE_E2E_PROXY_PASSWORD'),
+          '--location',
+          requiredEnv('MULLGATE_E2E_LOCATION'),
+        ],
+        env,
+      );
+
+      expect(setupResult.status).toBe(0);
+
+      const startResult = await runCli(['proxy', 'start'], env);
+      expect(startResult.status).toBe(0);
+
+      const statusResult = await runCli(['proxy', 'status'], env);
+      expect(statusResult.status).toBe(0);
+      expect(statusResult.stdout).toContain('runtime status: running');
+
+      const doctorResult = await runCli(['proxy', 'doctor'], env);
+      expect(doctorResult.status).toBe(0);
+
+      const stopResult = await runCli(['proxy', 'stop'], env);
+      expect(stopResult.status).toBe(0);
+    },
+  );
+});

--- a/test/runtime/docker-runtime.test.ts
+++ b/test/runtime/docker-runtime.test.ts
@@ -4,7 +4,9 @@ import {
   type ProcessExecution,
   type ProcessRunner,
   queryDockerComposeStatus,
+  readDockerComposeLogs,
   startDockerRuntime,
+  stopDockerRuntime,
 } from '../../src/runtime/docker-runtime.js';
 
 function createQueuedRunner(steps: ProcessExecution[]): ProcessRunner {
@@ -381,6 +383,99 @@ describe('queryDockerComposeStatus', () => {
         'Docker Compose returned runtime status that Mullgate could not parse as typed JSON.',
       cause: expect.stringContaining('Unexpected token'),
       artifactPath: '/tmp/mullgate/runtime/docker-compose.yml',
+    });
+  });
+});
+
+describe('stopDockerRuntime', () => {
+  it('returns structured metadata when compose down succeeds', async () => {
+    const result = await stopDockerRuntime({
+      composeFilePath: '/tmp/mullgate/runtime/docker-compose.yml',
+      checkedAt: '2026-03-21T06:05:00.000Z',
+      runner: createQueuedRunner([
+        {
+          exitCode: 0,
+          stdout: 'Docker Compose version v2.40.1\n',
+          stderr: '',
+        },
+        {
+          exitCode: 0,
+          stdout: 'Container mullgate-routing-layer-1  Removed\n',
+          stderr: '',
+        },
+      ]),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      phase: 'compose-down',
+      source: 'docker-compose',
+      checkedAt: '2026-03-21T06:05:00.000Z',
+      composeFilePath: '/tmp/mullgate/runtime/docker-compose.yml',
+      command: {
+        binary: 'docker',
+        args: [
+          'compose',
+          '--file',
+          '/tmp/mullgate/runtime/docker-compose.yml',
+          'down',
+          '--remove-orphans',
+        ],
+        cwd: '/tmp/mullgate/runtime',
+        rendered:
+          'docker compose --file /tmp/mullgate/runtime/docker-compose.yml down --remove-orphans',
+      },
+      message: 'Docker Compose stopped the Mullgate runtime bundle.',
+      stdout: 'Container mullgate-routing-layer-1  Removed\n',
+      stderr: '',
+    });
+  });
+});
+
+describe('readDockerComposeLogs', () => {
+  it('builds the expected compose logs command with tail control', async () => {
+    const result = await readDockerComposeLogs({
+      composeFilePath: '/tmp/mullgate/runtime/docker-compose.yml',
+      checkedAt: '2026-03-21T06:06:00.000Z',
+      tail: 50,
+      runner: createQueuedRunner([
+        {
+          exitCode: 0,
+          stdout: 'Docker Compose version v2.40.1\n',
+          stderr: '',
+        },
+        {
+          exitCode: 0,
+          stdout: 'route-proxy-1  | accepted connection\n',
+          stderr: '',
+        },
+      ]),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      phase: 'compose-logs',
+      source: 'docker-compose',
+      checkedAt: '2026-03-21T06:06:00.000Z',
+      composeFilePath: '/tmp/mullgate/runtime/docker-compose.yml',
+      command: {
+        binary: 'docker',
+        args: [
+          'compose',
+          '--file',
+          '/tmp/mullgate/runtime/docker-compose.yml',
+          'logs',
+          '--no-color',
+          '--tail',
+          '50',
+        ],
+        cwd: '/tmp/mullgate/runtime',
+        rendered:
+          'docker compose --file /tmp/mullgate/runtime/docker-compose.yml logs --no-color --tail 50',
+      },
+      message: 'Docker Compose returned the requested Mullgate runtime logs.',
+      stdout: 'route-proxy-1  | accepted connection\n',
+      stderr: '',
     });
   });
 });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,6 +4,7 @@
     "noEmit": false,
     "rootDir": "src",
     "outDir": "dist",
+    "sourceMap": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json-summary', 'lcov'],
       reportsDirectory: 'coverage',
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        statements: 80,
+        branches: 75,
+      },
     },
   },
 });


### PR DESCRIPTION
**What changed**

- add `mullgate proxy stop`, `mullgate proxy restart`, `mullgate proxy logs`, `mullgate version`, and `mullgate completions`
- add `mullgate proxy start --dry-run`
- refresh relay list rendering, start-path relay cache refresh, and runtime remediation messaging
- add the env-gated real-runtime e2e skeleton
- update README, usage docs, hosted docs, and bundled skill to match the expanded CLI surface
- bump release metadata to `v1.3.0`

**Verification**

- `make release-check`
- `npm pack --dry-run`
- `pnpm --dir docs/mullgate-docs types:check`

**Notes**

- `docs/pr17-idea-audit.md` records which Nightshift ideas were implemented, rejected, or already present on `main`
- `.dora/**` was left out of the PR on purpose